### PR TITLE
内存泄露和Log位置增加。

### DIFF
--- a/SeasLog/seaslog.c
+++ b/SeasLog/seaslog.c
@@ -885,7 +885,7 @@ PHPAPI int _seaslog_log(
     zend_class_entry *ce TSRMLS_DC
 )
 {
-    char *logger, *_log_path, *_date, *_time, *log_file_path, *log_info;
+    char *logger, *_log_path, *_date, *_time, *log_file_path, *log_info,*cur_time;
     int log_len, log_file_path_len;
 
     if (argc > 2) {
@@ -912,12 +912,7 @@ PHPAPI int _seaslog_log(
     efree(_log_path);
     efree(_date);
 
-    zval *file_path;
-    char * cur_time;
-    MAKE_STD_ZVAL(file_path);
-    ZVAL_STRING(file_path, log_file_path, 1);
-
-    log_file_path_len = Z_STRLEN_P(file_path);
+    log_file_path_len = strlen(file_path)+1;
 
     cur_time = mic_time();
     log_len = spprintf(&log_info, 0, "%s:%d| %s | %d | %s | %s | %s \n",zend_get_executed_filename(TSRMLS_C),zend_get_executed_lineno(TSRMLS_C), level, getpid(), cur_time, _time, message);
@@ -930,8 +925,6 @@ PHPAPI int _seaslog_log(
     }
     
     efree(log_info);
-    efree(log_file_path);
-    zval_ptr_dtor(&file_path);
     return SUCCESS;
 }
 
@@ -997,7 +990,7 @@ PHPAPI int _ck_log_dir(char *dir TSRMLS_DC)
 
     zval_ptr_dtor(&str);
     zval_ptr_dtor(&function_name);
-    
+
     if (retval != NULL && zval_is_true(retval)) {
         zval_ptr_dtor(&retval);
         return SUCCESS;

--- a/SeasLog/seaslog.c
+++ b/SeasLog/seaslog.c
@@ -912,7 +912,7 @@ PHPAPI int _seaslog_log(
     efree(_log_path);
     efree(_date);
 
-    log_file_path_len = strlen(file_path)+1;
+    log_file_path_len = strlen(log_file_path)+1;
 
     cur_time = mic_time();
     log_len = spprintf(&log_info, 0, "%s:%d| %s | %d | %s | %s | %s \n",zend_get_executed_filename(TSRMLS_C),zend_get_executed_lineno(TSRMLS_C), level, getpid(), cur_time, _time, message);
@@ -920,10 +920,11 @@ PHPAPI int _seaslog_log(
     efree(cur_time);
 
     if (_php_log_ex(log_info, log_len, log_file_path, log_file_path_len, ce TSRMLS_CC) == FAILURE) {
+        efree(log_file_path);
         efree(log_info);
         return FAILURE;
     }
-    
+    efree(log_file_path);
     efree(log_info);
     return SUCCESS;
 }

--- a/SeasLog/seaslog.c
+++ b/SeasLog/seaslog.c
@@ -230,6 +230,7 @@ void seaslog_clear_buffer(TSRMLS_D)
     zend_update_static_property(seaslog_ce, SL_S(SEASLOG_BUFFER_SIZE_NAME), buffer_size TSRMLS_CC);
 }
 
+//每次log都打开关闭流 @todo
 static int real_php_log_ex(char *message, int message_len, char *opt TSRMLS_DC)
 {
     php_stream *stream = NULL;
@@ -756,7 +757,7 @@ PHP_METHOD(SEASLOG_RES_NAME, emergency)
     seaslog_log_by_level_common(INTERNAL_FUNCTION_PARAM_PASSTHRU, SEASLOG_EMERGENCY);
 }
 
-static char *php_strtr_array(char *str, int slen, HashTable *hash)
+static char* php_strtr_array(char *str, int slen, HashTable *hash)
 {
     zval **entry;
     char  *string_key;
@@ -840,7 +841,6 @@ static char *php_strtr_array(char *str, int slen, HashTable *hash)
                     tval = Z_STRVAL_PP(trans);
                     tlen = Z_STRLEN_PP(trans);
                 }
-
                 smart_str_appendl(&result, tval, tlen);
                 pos += len;
                 found = 1;
@@ -874,8 +874,9 @@ PHPAPI int _seaslog_log_content(
 )
 {
     char *result = php_strtr_array(message, message_len, content);
-
-    return _seaslog_log(argc, level, result, strlen(result), module, module_len, ce TSRMLS_CC);
+    int ret =  _seaslog_log(argc, level, result, strlen(result), module, module_len, ce TSRMLS_CC);
+    efree(result);
+    return ret;
 }
 
 PHPAPI int _seaslog_log(


### PR DESCRIPTION
主要修复了spprintf，php_format_date 引起的内存泄露。
另外，日志添加了脚步名和当前行数
日志输出格式为：
XX/test3.php:2| error | 42925 | 1430927135.25 | 2015:05:06 23:45:35 | this is a error test by ::log
XX/test3.php 为全路径，2为第二行
