### PR TITLE
解决php5.3+SUSE下自动创建日志目录无进入权限问题

### DIFF
--- a/SeasLog/seaslog.c
+++ b/SeasLog/seaslog.c
@@ -945,6 +945,7 @@ PHPAPI int _mk_log_dir(char *dir TSRMLS_DC)
 
     if (_ck_dir == FAILURE) {
         zval *zcontext = NULL;
+        umask(1);
         long mode = 0777;
         zend_bool recursive = 1;
         php_stream_context *context;


### PR DESCRIPTION
遇到问题是在php5.3+suse环境下，php5.6+mac 上测试没问题，没有进一步更多系统上测试。

自动创建目录是 666 权限。无法进入和创建二级目录跟日志文件。
