### PR TITLE
修复各种内存泄漏.

### DIFF
--- a/php_seaslog.h
+++ b/php_seaslog.h
@@ -33,7 +33,7 @@ extern zend_module_entry seaslog_module_entry;
 #endif
 
 #define SEASLOG_RES_NAME                    "SeasLog"
-#define SEASLOG_VERSION                     "1.5.4"
+#define SEASLOG_VERSION                     "1.5.4-wangyi"
 #define SEASLOG_AUTHOR                      "Chitao.Gao  [ neeke@php.net ]"
 
 #define SEASLOG_ALL                         "all"

--- a/seaslog.c
+++ b/seaslog.c
@@ -1261,7 +1261,7 @@ PHP_METHOD(SEASLOG_RES_NAME, emergency)
 }
 
 /*Just used by PHP7*/
-// We asure the src is on heap, so every call we can safe free than alloc.
+// We assume the src is on heap, so every call we can safe free than alloc.
 char *strreplace(char *src, const char *oldstr, const char *newstr, size_t len)
 {
     if(strcmp(oldstr, newstr)==0) {
@@ -1304,7 +1304,7 @@ static char *php_strtr_array(char *str, int slen, HashTable *pats)
         } else {
             zend_string *s = zval_get_string(entry);
 
-            if (strstr(str,ZSTR_VAL(str_key))) {
+            if (strstr(tmp,ZSTR_VAL(str_key))) {
                 tmp = strreplace(tmp,ZSTR_VAL(str_key),ZSTR_VAL(s),strlen(str));
             }
 
@@ -1313,7 +1313,7 @@ static char *php_strtr_array(char *str, int slen, HashTable *pats)
     }
     ZEND_HASH_FOREACH_END();
 
-    return str;
+    return tmp;
 }
 
 #else


### PR DESCRIPTION
在cli模式下使用Seaslog会有大量内存泄漏, 原因是一些通过spprintf返回的字符串没有efree掉, 修改后, test.php可以长期运行内存稳定.

<test.php>

```
<?php

function format($mMsg, $sMethod = '', $sLine = '')
    {
        if (is_array($mMsg)) {
            $mMsg = var_export($mMsg, true);
        }

        $sMsg  = sprintf("%s | %s | %s\n", "TestModule", $sMethod, $sLine);
        $sMsg .= $mMsg;
        $sMsg .= "\n\n";

        return $sMsg;
    }

function test_log()
{
        $iCount = 10000;
        while ($iCount-- > 0) {
                SeasLog::error(format(['msg' => "HelloWorld", 'id' => $iCount], "__main__", '123'), [], 'test1');
        }

        $iCount = 10000;
        while ($iCount-- > 0) {
                SeasLog::info(format(['msg' => "HelloWorld", 'id' => $iCount], "__main__", '123'), [], 'test2');
        }

        $iCount = 10000;
        while ($iCount-- > 0) {
                SeasLog::debug(format(['msg' => "HelloWorld", 'id' => $iCount], "__main__", '123'));
        }
}

while (True) {
        sleep(1);
        test_log();
}
```
