### PR TITLE
fix bug 

### DIFF
--- a/Analyzer/core/analyzer/pcntl.php
+++ b/Analyzer/core/analyzer/pcntl.php
@@ -43,7 +43,7 @@ class pcntl extends analyzerBase
         //线程数大于配置数，每个配置一个线程
         if ($_analyz_count <= self::$forkCount) {
             self::$forkCount = $_analyz_count;
-            return array_chunk($_analyz, $_analyz_count, TRUE);
+            return array_chunk($_analyz, 1, TRUE);
         }
 
         //平均分配置到线程数，最后一个线程分得最多个


### PR DESCRIPTION
### bug
`Notice: Undefined offset: 1 in /data/laboratory/Analyzer/core/analyzer/pcntl.php on line 79`
### explanation
1. 线程数大于等于【analyz】里的module的时候，array_chunk的第二个参数应该是1，而不是配置里面的线程数。
2. 否则会导致在pcntl::run的时候$batchArray[$i]会报Undefined offset。