### PR TITLE
fix bugs for compiling failure on mac osx when compiling on master br…

### DIFF
--- a/src/Datetime.c
+++ b/src/Datetime.c
@@ -101,7 +101,7 @@ static int mic_time(smart_str *buf)
     smart_str_appendc(buf,'.');
     smart_str_append_long(buf,(long)now.tv_usec / 1000);
 
-    return;
+    return 0;
 }
 
 static char *make_time_RFC3339(TSRMLS_D)

--- a/src/TemplateFormatter.c
+++ b/src/TemplateFormatter.c
@@ -181,5 +181,5 @@ skip_output:
         smart_str_free(&tmp_time);
     }
 
-	return;
+	return 0;
 }


### PR DESCRIPTION
修复主干分支在mac osx下编译出错的bug。
mic_time应该不需要返回值，尊重作者的写法这里直接返回了0;
seaslog_template_formatter也采用了同样的处理方式。