### PR TITLE
修复php7.1版本cli下运行不正常的bug! 

### DIFF
--- a/src/Request.c
+++ b/src/Request.c
@@ -193,7 +193,12 @@ static int seaslog_init_request_variable(TSRMLS_D)
 static void seaslog_clear_request_variable(TSRMLS_D)
 {
     SEASLOG_ZVAL_PTR_DTOR(SEASLOG_G(request_variable)->request_uri);
-    SEASLOG_ZVAL_PTR_DTOR(SEASLOG_G(request_variable)->request_method);
+    
+    if( SEASLOG_G(request_variable)->request_method )
+    {
+        SEASLOG_ZVAL_PTR_DTOR(SEASLOG_G(request_variable)->request_method);
+    }
+    
     efree(SEASLOG_G(request_variable)->domain_port);
     efree(SEASLOG_G(request_variable)->client_ip);
     efree(SEASLOG_G(request_variable));


### PR DESCRIPTION
修复php7.1版本cli下运行不正常的bug! 原因：超全局变量$_SERVER中不存在SUDO_COMMAND导致SEASLOG_G(request_variable)->request_method为空进而导致seaslog_clear_request_variable函数中SEASLOG_ZVAL_PTR_DTOR(SEASLOG_G(request_variable)->request_method);失败