### PR TITLE
修复设置 SEASLOG_* 后，统计日志全部为 ERROR

### DIFF
--- a/Analyzer/core/analyzer/analyzerBase.php
+++ b/Analyzer/core/analyzer/analyzerBase.php
@@ -19,7 +19,7 @@ class analyzerBase
 
         \SeasLog::setLogger($config['module']);
 
-        $logLevel = intval($config['level']);
+        $logLevel = $config['level'];
         if (empty($logLevel)) {
             $logLevel = SEASLOG_ERROR;
         }


### PR DESCRIPTION
analyzerCount 函数参数为字符串
$config['level'] 不用转为 int