### PR TITLE
fix: `%F` in `default_template` trigger cordump in CLI mode

### DIFF
--- a/include/php7_wrapper.h
+++ b/include/php7_wrapper.h
@@ -36,6 +36,7 @@
 # define SEASLOG_ZEND_HASH_INDEX_UPDATE(ht, h, pData, nDataSize, pDest)  zend_hash_index_update_ptr(ht, h, pData)
 # define SEASLOG_SMART_STR_C(str) ZSTR_VAL(str.s)
 # define SEASLOG_SMART_STR_L(str) ZSTR_LEN(str.s)
+# define SEASLOG_SMART_STR_GET_LEN(str) (str.s ? ZSTR_LEN(str.s) : 0)
 # define SEASLOG_AUTO_GLOBAL(n) zend_is_auto_global_str(ZEND_STRL(n) TSRMLS_CC)
 # define SEASLOG_ZVAL_PTR_DTOR(z) zval_ptr_dtor(z)
 

--- a/src/TemplateFormatter.c
+++ b/src/TemplateFormatter.c
@@ -114,7 +114,7 @@ int seaslog_spprintf(char **pbuf TSRMLS_DC, int generate_type, char *level, size
 void seaslog_template_formatter(smart_str *xbuf TSRMLS_DC, int generate_type, const char *fmt, char *level, va_list ap)
 {
     char *s = NULL;
-    int s_len;
+    int s_len = 0;
 
     char char_buf[2];
     smart_str tmp_buf = {0};
@@ -264,8 +264,12 @@ void seaslog_template_formatter(smart_str *xbuf TSRMLS_DC, int generate_type, co
                         smart_str_free(&tmp_buf);
                     }
                     get_code_filename_line(&tmp_buf TSRMLS_CC);
-                    s = SEASLOG_SMART_STR_C(tmp_buf);
-                    s_len  = SEASLOG_SMART_STR_L(tmp_buf);
+
+                    if (SEASLOG_SMART_STR_GET_LEN(tmp_buf) > 0) {
+                        s = SEASLOG_SMART_STR_C(tmp_buf);
+                        s_len  = SEASLOG_SMART_STR_L(tmp_buf);
+                    }
+
                     break;
                 case 'U': //zend_memory_usage
                     if (SEASLOG_SMART_STR_C(tmp_buf))
@@ -299,7 +303,9 @@ void seaslog_template_formatter(smart_str *xbuf TSRMLS_DC, int generate_type, co
             break;
             }
 
-            INS_STRING(xbuf, s, s_len);
+            if (s_len > 0) {
+                INS_STRING(xbuf, s, s_len);
+            }
         }
 skip_output:
         fmt++;


### PR DESCRIPTION
php file `a.php`:
<?php
function a()
{
    sleep(1);
}

a();
?>

run:
php a.php