### PR TITLE
fix coredump : ignore php errors before module initialized

### DIFF
--- a/include/Buffer.h
+++ b/include/Buffer.h
@@ -19,7 +19,7 @@
 
 #include "php_seaslog.h"
 
-void initBufferSwitch(TSRMLS_D);
+void init_buffer_switch(TSRMLS_D);
 void seaslog_init_buffer(TSRMLS_D);
 void seaslog_shutdown_buffer(int re_init TSRMLS_DC);
 void seaslog_clear_buffer(TSRMLS_D);

--- a/include/Datetime.h
+++ b/include/Datetime.h
@@ -20,7 +20,7 @@
 #include "php_seaslog.h"
 
 char *make_real_time(TSRMLS_D);
-void initRemoteTimeout(TSRMLS_D);
+void init_remote_timeout(TSRMLS_D);
 char *seaslog_process_last_sec(int now, int if_first TSRMLS_DC);
 void mic_time(smart_str *buf);
 char *make_time_RFC3339(TSRMLS_D);

--- a/include/ErrorHook.h
+++ b/include/ErrorHook.h
@@ -19,8 +19,8 @@
 
 #include "php_seaslog.h"
 
-void initErrorHooks(TSRMLS_D);
-void recoveryErrorHooks(TSRMLS_D);
+void init_error_hooks(TSRMLS_D);
+void recovery_error_hooks(TSRMLS_D);
 
 #endif /* _SEASLOG_ERRORHOOK_H_ */
 

--- a/include/ExceptionHook.h
+++ b/include/ExceptionHook.h
@@ -20,8 +20,8 @@
 #include "php_seaslog.h"
 
 void seaslog_throw_exception(int type TSRMLS_DC, const char *format, ...);
-void initExceptionHooks(TSRMLS_D);
-void recoveryExceptionHooks(TSRMLS_D);
+void init_exception_hooks(TSRMLS_D);
+void recovery_exception_hooks(TSRMLS_D);
 void seaslog_throw_exception_hook(zval *exception TSRMLS_DC);
 
 #endif /* _SEASLOG_EXCEPTIONHOOK_H_ */

--- a/include/Performance.h
+++ b/include/Performance.h
@@ -22,11 +22,9 @@
 void seaslog_memory_usage(smart_str *buf TSRMLS_DC);
 void seaslog_peak_memory_usage(smart_str *buf TSRMLS_DC);
 
-void initZendHooks(TSRMLS_D);
-void recoveryZendHooks(TSRMLS_D);
+void init_zend_hooks(TSRMLS_D);
+void recovery_zend_hooks(TSRMLS_D);
 
-static inline int seaslog_process_performance_sample(TSRMLS_D);
-static inline int seaslog_check_performance_sample(TSRMLS_D);
 void seaslog_rinit_performance(TSRMLS_D);
 void seaslog_clear_performance(zend_class_entry *ce TSRMLS_DC);
 int seaslog_check_performance_active(TSRMLS_D);
@@ -38,7 +36,6 @@ seaslog_frame* seaslog_performance_fast_alloc_frame(TSRMLS_D);
 void seaslog_performance_fast_free_frame(seaslog_frame *p TSRMLS_DC);
 void seaslog_performance_free_the_free_list(TSRMLS_D);
 
-static inline void seaslog_performance_bucket_process(seaslog_frame* current_frame TSRMLS_DC);
 void seaslog_performance_bucket_free(seaslog_performance_bucket *bucket TSRMLS_DC);
 
 char* seaslog_performance_get_class_name(zend_execute_data *data TSRMLS_DC);

--- a/seaslog.c
+++ b/seaslog.c
@@ -260,20 +260,20 @@ PHP_MINIT_FUNCTION(seaslog)
 
     seaslog_ce->ce_flags = ZEND_ACC_IMPLICIT_PUBLIC;
 
-    initErrorHooks(TSRMLS_C);
-    initExceptionHooks(TSRMLS_C);
-    initBufferSwitch(TSRMLS_C);
-    initRemoteTimeout(TSRMLS_C);
-    initZendHooks(TSRMLS_C);
+    init_error_hooks(TSRMLS_C);
+    init_exception_hooks(TSRMLS_C);
+    init_buffer_switch(TSRMLS_C);
+    init_remote_timeout(TSRMLS_C);
+    init_zend_hooks(TSRMLS_C);
 
     return SUCCESS;
 }
 
 PHP_MSHUTDOWN_FUNCTION(seaslog)
 {
-    recoveryErrorHooks(TSRMLS_C);
-    recoveryExceptionHooks(TSRMLS_C);
-    recoveryZendHooks(TSRMLS_C);
+    recovery_error_hooks(TSRMLS_C);
+    recovery_exception_hooks(TSRMLS_C);
+    recovery_zend_hooks(TSRMLS_C);
 
     UNREGISTER_INI_ENTRIES();
 

--- a/src/Buffer.c
+++ b/src/Buffer.c
@@ -18,7 +18,7 @@
 #include "Common.h"
 #include "StreamWrapper.h"
 
-void initBufferSwitch(TSRMLS_D)
+void init_buffer_switch(TSRMLS_D)
 {
     SEASLOG_G(enable_buffer_real) = FAILURE;
 

--- a/src/Datetime.c
+++ b/src/Datetime.c
@@ -30,7 +30,7 @@ static char *seaslog_format_date(char *format, int format_len, time_t ts TSRMLS_
 #endif
 }
 
-void initRemoteTimeout(TSRMLS_D)
+void init_remote_timeout(TSRMLS_D)
 {
 #ifndef PHP_WIN32
     time_t conv;
@@ -95,8 +95,6 @@ char *seaslog_process_last_min(int now, int if_first TSRMLS_DC)
 
 char *make_real_date(TSRMLS_D)
 {
-    char *_date = NULL;
-
     int now = (long)time(NULL);
     if (now > SEASLOG_G(last_min)->sec + 60)
     {

--- a/src/ErrorHook.c
+++ b/src/ErrorHook.c
@@ -39,7 +39,16 @@ static void process_event_error(const char *event_type, int type, char * error_f
 void seaslog_error_cb(int type, const char *error_filename, const uint error_lineno, const char *format, va_list args)
 {
     TSRMLS_FETCH();
-    if (SEASLOG_G(trace_error) || SEASLOG_G(trace_warning) || SEASLOG_G(trace_notice))
+    if (SEASLOG_G(initRComplete) != SEASLOG_INITR_COMPLETE_YES)
+    {
+        return old_error_cb(type, error_filename, error_lineno, format, args);
+    }
+
+    if (SEASLOG_G(trace_error)
+            || SEASLOG_G(last_min)
+            || SEASLOG_G(last_logger)
+            || SEASLOG_G(trace_warning)
+            || SEASLOG_G(trace_notice))
     {
         char *msg;
         va_list args_copy;

--- a/src/ErrorHook.c
+++ b/src/ErrorHook.c
@@ -76,13 +76,13 @@ void seaslog_error_cb(int type, const char *error_filename, const uint error_lin
     old_error_cb(type, error_filename, error_lineno, format, args);
 }
 
-void initErrorHooks(TSRMLS_D)
+void init_error_hooks(TSRMLS_D)
 {
     old_error_cb = zend_error_cb;
     zend_error_cb = seaslog_error_cb;
 }
 
-void recoveryErrorHooks(TSRMLS_D)
+void recovery_error_hooks(TSRMLS_D)
 {
     if (old_error_cb)
     {

--- a/src/ExceptionHook.c
+++ b/src/ExceptionHook.c
@@ -69,7 +69,7 @@ void seaslog_throw_exception_hook(zval *exception TSRMLS_DC)
     }
 }
 
-void initExceptionHooks(TSRMLS_D)
+void init_exception_hooks(TSRMLS_D)
 {
     if (SEASLOG_G(trace_exception))
     {
@@ -82,7 +82,7 @@ void initExceptionHooks(TSRMLS_D)
     }
 }
 
-void recoveryExceptionHooks(TSRMLS_D)
+void recovery_exception_hooks(TSRMLS_D)
 {
     if (SEASLOG_G(trace_exception))
     {

--- a/src/StreamWrapper.c
+++ b/src/StreamWrapper.c
@@ -192,6 +192,7 @@ php_stream *process_stream(char *opt, int opt_len TSRMLS_DC)
     HashTable *ht_list;
     php_stream_statbuf dest_s;
     stream_entry_t *stream_entry;
+    int flag = HASH_ADD;
 
     switch SEASLOG_G(appender)
     {
@@ -227,6 +228,7 @@ php_stream *process_stream(char *opt, int opt_len TSRMLS_DC)
             default:
                 if (php_stream_stat_path_ex(opt, PHP_STREAM_URL_STAT_QUIET | PHP_STREAM_URL_STAT_NOCACHE, &dest_s, NULL) < 0)
                 {
+                    flag = HASH_UPDATE;
                     goto create_stream;
                 }
             }
@@ -256,6 +258,7 @@ php_stream *process_stream(char *opt, int opt_len TSRMLS_DC)
             default:
                 if (php_stream_stat_path_ex(opt, PHP_STREAM_URL_STAT_QUIET | PHP_STREAM_URL_STAT_NOCACHE, &dest_s, NULL) < 0)
                 {
+                    flag = HASH_UPDATE;
                     goto create_stream;
                 }
             }
@@ -288,7 +291,25 @@ create_stream:
             stream_entry->stream = stream;
             stream_entry->can_delete = SEASLOG_CLOSE_LOGGER_STREAM_CAN_DELETE;
 
-            SEASLOG_ZEND_HASH_INDEX_ADD(ht_list, stream_entry_hash, stream_entry, sizeof(stream_entry_t));
+            if (flag == HASH_ADD)
+            {
+                SEASLOG_ZEND_HASH_INDEX_ADD(
+                    ht_list,
+                    stream_entry_hash,
+                    stream_entry,
+                    sizeof(stream_entry_t)
+                );
+            }
+            else
+            {
+                SEASLOG_ZEND_HASH_INDEX_UPDATE(
+                    ht_list,
+                    stream_entry_hash,
+                    stream_entry,
+                    sizeof(stream_entry_t),
+                    NULL
+                );
+            }
 
             return stream;
         }


### PR DESCRIPTION
- fix coredump : ignore php errors before module initialized
- follow ansi coding style