### PR TITLE
define ZEND_ACC_IMPLICIT_PUBLIC  ZEND_ACC_PUBLIC

### DIFF
--- a/include/php7_wrapper.h
+++ b/include/php7_wrapper.h
@@ -14,6 +14,10 @@
   +----------------------------------------------------------------------+
 */
 
+#if !defined(ZEND_ACC_IMPLICIT_PUBLIC)
+# define ZEND_ACC_IMPLICIT_PUBLIC ZEND_ACC_PUBLIC
+#endif
+
 #if PHP_VERSION_ID >= 70000
 
 # define SEASLOG_MAKE_ZVAL(z) zval _stack_zval_##z; z = &(_stack_zval_##z)


### PR DESCRIPTION
define ZEND_ACC_IMPLICIT_PUBLIC  ZEND_ACC_PUBLIC

Get rid of ZEND_ACC_IMPLICIT_PUBLIC     https://github.com/php/php-src/commit/034b7ff09143e3d86d6e4f8c15728b52b0c413d7  

fix: https://github.com/SeasX/SeasLog/issues/268