### PR TITLE
modify trim_wrap

### DIFF
--- a/include/SeasLog.h
+++ b/include/SeasLog.h
@@ -98,7 +98,7 @@
 
 #define SEASLOG_BUFFER_MAX_SIZE                 65535
 
-#define SEASLOG_TRIM_WRAP                       26
+#define SEASLOG_TRIM_WRAP                       32
 
 #define SEASLOG_EXCEPTION_LOGGER_ERROR          4403
 #define SEASLOG_EXCEPTION_CONTENT_ERROR         4406

--- a/src/Common.c
+++ b/src/Common.c
@@ -255,7 +255,7 @@ char* php_strtr_array(char *str, int slen, HashTable *hash)
 int message_trim_wrap(char *message,int message_len TSRMLS_DC)
 {
     int i;
-    for (i=0; i<=message_len; i++)
+    for (i=0; i<message_len; i++)
     {
         if(message[i] == '\r' || message[i] == '\n')
         {


### PR DESCRIPTION
十进制的32才是空格
十六进制的26才是空格
所以替换`\r`和`\n`会有问题
而且trim_warpfor循环多了一次