### PR TITLE
fix core dump

### DIFF
--- a/src/Request.c
+++ b/src/Request.c
@@ -326,7 +326,7 @@ void get_code_filename_line(smart_str *result TSRMLS_DC)
         }
         else if (ptr->prev_execute_data && ptr->prev_execute_data->opline)
         {
-            ret = ptr->op_array->filename;
+            ret = ptr->prev_execute_data->op_array->filename;
             retlen = strlen(ret);
             code_line = ptr->prev_execute_data->opline->lineno;
         }

--- a/src/Request.c
+++ b/src/Request.c
@@ -236,6 +236,7 @@ void seaslog_clear_request_variable(TSRMLS_D)
 void get_code_filename_line(smart_str *result TSRMLS_DC)
 {
     const char *ret;
+    size_t retlen = 0;
     long code_line = 0;
     size_t filename_len;
     int recall_depth = SEASLOG_G(recall_depth);
@@ -245,6 +246,7 @@ void get_code_filename_line(smart_str *result TSRMLS_DC)
     if (SEASLOG_G(in_error) == 1)
     {
         ret = SEASLOG_G(in_error_filename);
+        retlen = strlen(ret);
         code_line = SEASLOG_G(in_error_lineno);
     }
     else
@@ -273,11 +275,12 @@ void get_code_filename_line(smart_str *result TSRMLS_DC)
         if (ptr->func && ZEND_USER_CODE(ptr->func->type))
         {
             ret = ZSTR_VAL(ptr->func->op_array.filename);
+            retlen = strlen(ret);
             code_line = ptr->opline->lineno;
         }
     }
 
-    filename = php_basename(ret, strlen(ret), NULL, 0);
+    filename = php_basename(ret, retlen, NULL, 0);
 
     smart_str_appendl(result,ZSTR_VAL(filename),ZSTR_LEN(filename));
     smart_str_appendc(result,':');
@@ -291,6 +294,7 @@ void get_code_filename_line(smart_str *result TSRMLS_DC)
     if (SEASLOG_G(in_error) == 1)
     {
         ret = SEASLOG_G(in_error_filename);
+        retlen = strlen(ret);
         code_line = SEASLOG_G(in_error_lineno);
     }
     else
@@ -317,19 +321,21 @@ void get_code_filename_line(smart_str *result TSRMLS_DC)
         if (ptr->op_array)
         {
             ret = ptr->op_array->filename;
+            retlen = strlen(ret);
             code_line = ptr->opline->lineno;
         }
         else if (ptr->prev_execute_data && ptr->prev_execute_data->opline)
         {
             ret = ptr->op_array->filename;
+            retlen = strlen(ret);
             code_line = ptr->prev_execute_data->opline->lineno;
         }
     }
 
 #if PHP_VERSION_ID >= 50400
-    php_basename(ret, strlen(ret), NULL, 0, &filename, &filename_len TSRMLS_CC);
+    php_basename(ret, retlen, NULL, 0, &filename, &filename_len TSRMLS_CC);
 #else
-    php_basename((char *)ret, strlen(ret), NULL, 0, &filename, &filename_len TSRMLS_CC);
+    php_basename((char *)ret, retlen, NULL, 0, &filename, &filename_len TSRMLS_CC);
 #endif
 
     smart_str_appendl(result,filename,filename_len);

--- a/tests/022.phpt
+++ b/tests/022.phpt
@@ -11,7 +11,7 @@ if (!extension_loaded('seaslog'))
 ?>
 --FILE--
 <?php
-
+SeasLog::setBasePath('base_path');
 class Log
 {
     public static function __callStatic($name, $arguments)

--- a/tests/022.phpt
+++ b/tests/022.phpt
@@ -2,6 +2,7 @@
 pr 284
 --INI--
 seaslog.default_template = "%M|%F"
+seaslog.default_basepath="base_path"
 --SKIPIF--
 <?php
 if (!extension_loaded('seaslog'))

--- a/tests/022.phpt
+++ b/tests/022.phpt
@@ -17,7 +17,7 @@ class Log
 {
     public static function __callStatic($name, $arguments)
     {
-        forward_static_call_array(['SeasLog', $name], $arguments);
+        forward_static_call_array(array('SeasLog', $name), $arguments);
     }
 
 }

--- a/tests/022.phpt
+++ b/tests/022.phpt
@@ -1,0 +1,27 @@
+--TEST--
+pr 284
+--INI--
+seaslog.default_template = "%M|%F"
+--SKIPIF--
+<?php
+if (!extension_loaded('seaslog'))
+{
+    print 'skip';
+}
+?>
+--FILE--
+<?php
+class Log
+{
+    // 代理seaslog的静态方法，如 Seaslog::debug
+    public static function __callStatic($name, $arguments)
+    {
+        forward_static_call_array(['SeasLog', $name], $arguments);
+    }
+
+}
+Log::error("aaa");
+var_dump(10)
+?>
+--EXPECT--
+int(10)

--- a/tests/022.phpt
+++ b/tests/022.phpt
@@ -11,9 +11,9 @@ if (!extension_loaded('seaslog'))
 ?>
 --FILE--
 <?php
+
 class Log
 {
-    // 代理seaslog的静态方法，如 Seaslog::debug
     public static function __callStatic($name, $arguments)
     {
         forward_static_call_array(['SeasLog', $name], $arguments);
@@ -21,7 +21,7 @@ class Log
 
 }
 Log::error("aaa");
-var_dump(10)
+var_dump(true);
 ?>
 --EXPECT--
-int(10)
+bool(true)


### PR DESCRIPTION
core dump 堆栈
```
#0  strlen () at ../sysdeps/x86_64/strlen.S:106
#1  0x00007f1fcb9c9601 in seaslog_clear_request_variable () at /home/dinosaur/SeasLog/src/Request.c:223
#2  0x00007f1fcb9c52e4 in seaslog_template_formatter (xbuf=0x7ffe611d33e0, generate_type=2, fmt=0x7f1fcc6810a4 "F", level=0x7f1fcb9ca6f8 "exception", ap=0x7ffe611d33f0) at /home/dinosaur/SeasLog/src/TemplateFormatter.c:293
#3  0x00007f1fcb9c4c62 in seaslog_spprintf (pbuf=0x7ffe611d3518, generate_type=2, level=0x7f1fcb9ca6f8 "exception", max_len=0) at /home/dinosaur/SeasLog/src/TemplateFormatter.c:131
#4  0x00007f1fcb9c5f8f in appender_handle_tcp_udp (message=0x7f1fc2fb1ce0 "aaa", message_len=3, level=0x7f1fcb9ca6f8 "exception", level_int=3, logger=0x7f1fcc67ca50, ce=0x24e29b0) at /home/dinosaur/SeasLog/src/Appender.c:115
#5  0x00007f1fcb9c615d in appender_handle_file (
    message=0x7f1fcb9cb238 "J+bi0HAHmIYrbMaB0I9yKHKjQMiBxaD4G3wTwESPl/x1otR8O90KWpdQAQdVt/OFdn2m5yPUDUfc0QIOihynpD0Q4gNjAzWs5YL9xdbkVOd96vkHO2ZFo2FH9/nHbIs63ks7Zk6gSZzGs/paPjPa8tYW/S0rE9cUH2/GhkZhhpvlJwy+F2fHpogn82Jk+6Km6vzH5bic"..., message_len=0, level=0x7f1fcb9c615d <appender_handle_file+251> "\211E܋E؍H\001H\213U\340H\213E\350H\213}\250\213u\334I\211\370H\211\307\350\333\374\377\377\203\370\377uMH\213E\340A\270", level_int=1, 
    logger=0x7ffe611d3580, ce=0x62303514974fee00) at /home/dinosaur/SeasLog/src/Appender.c:144
#6  0x00007f1fcb9bf077 in seaslog_log_context_ex (argc=1, check_argc=1, level=0x7f1fcb9ca6f8 "exception", level_int=3, message=0x7f1fc2fb1ce0 "aaa", message_len=3, context=0x0, 
    module=0x7f1fcb9cb238 "J+bi0HAHmIYrbMaB0I9yKHKjQMiBxaD4G3wTwESPl/x1otR8O90KWpdQAQdVt/OFdn2m5yPUDUfc0QIOihynpD0Q4gNjAzWs5YL9xdbkVOd96vkHO2ZFo2FH9/nHbIs63ks7Zk6gSZzGs/paPjPa8tYW/S0rE9cUH2/GhkZhhpvlJwy+F2fHpogn82Jk+6Km6vzH5bic"..., module_len=0, seaslog_ce=0x24e29b0) at /home/dinosaur/SeasLog/seaslog.c:374
#7  0x00007f1fcb9bf206 in seaslog_log_by_level_common_ex (argc=1, check_argc=1, level=0x7f1fcb9ca6f8 "exception", level_int=3, messages=0x7f1fcc61e1d0, context=0x0, 
    logger_str=0x7f1fcb9cb238 "J+bi0HAHmIYrbMaB0I9yKHKjQMiBxaD4G3wTwESPl/x1otR8O90KWpdQAQdVt/OFdn2m5yPUDUfc0QIOihynpD0Q4gNjAzWs5YL9xdbkVOd96vkHO2ZFo2FH9/nHbIs63ks7Zk6gSZzGs/paPjPa8tYW/S0rE9cUH2/GhkZhhpvlJwy+F2fHpogn82Jk+6Km6vzH5bic"..., logger_len=0, seaslog_ce=0x24e29b0) at /home/dinosaur/SeasLog/seaslog.c:411
#8  0x00007f1fcb9bf3bc in seaslog_log_by_level_common (execute_data=0x7f1fcc61e180, return_value=0x7ffe611d38f0, level=0x7f1fcb9ca6f8 "exception", level_int=3) at /home/dinosaur/SeasLog/seaslog.c:499
#9  0x00007f1fcb9c0c1a in zim_SEASLOG_RES_NAME_log (execute_data=0x7f1fcc61e1d0, return_value=0x100000000) at /home/dinosaur/SeasLog/seaslog.c:1153
#10 0x0000000000a1cff8 in zend_call_function (fci=0x7ffe611d3930, fci_cache=0x7ffe611d3900) at /home/dinosaur/Downloads/php-7.2.2/Zend/zend_execute_API.c:833
#11 0x000000000083bcb3 in zif_forward_static_call_array (execute_data=0x7f1fcc61e110, return_value=0x7ffe611d39b0) at /home/dinosaur/Downloads/php-7.2.2/ext/standard/basic_functions.c:4975
#12 0x0000000000aae986 in ZEND_DO_ICALL_SPEC_RETVAL_UNUSED_HANDLER () at /home/dinosaur/Downloads/php-7.2.2/Zend/zend_vm_execute.h:573
#13 0x0000000000b4295e in execute_ex (ex=0x7f1fcc61e030) at /home/dinosaur/Downloads/php-7.2.2/Zend/zend_vm_execute.h:59731
#14 0x0000000000b47d9d in zend_execute (op_array=0x7f1fcc682b00, return_value=0x0) at /home/dinosaur/Downloads/php-7.2.2/Zend/zend_vm_execute.h:63760
#15 0x0000000000a3afe0 in zend_execute_scripts (type=8, retval=0x0, file_count=3) at /home/dinosaur/Downloads/php-7.2.2/Zend/zend.c:1496
#16 0x000000000098c749 in php_execute_script (primary_file=0x7ffe611d6090) at /home/dinosaur/Downloads/php-7.2.2/main/main.c:2590
#17 0x0000000000b4b2a5 in do_cli (argc=2, argv=0x2322d80) at /home/dinosaur/Downloads/php-7.2.2/sapi/cli/php_cli.c:1011
#18 0x0000000000b4c491 in main (argc=2, argv=0x2322d80) at /home/dinosaur/Downloads/php-7.2.2/sapi/cli/php_cli.c:1404

```

 `const char *ret;` 没有被赋值过，然后strlen(ret)访问了只读地址导致core dump