### PR TITLE
remove tsrmls_macro

### DIFF
--- a/include/Analyzer.h
+++ b/include/Analyzer.h
@@ -19,8 +19,8 @@
 
 #include "php_seaslog.h"
 
-long get_type_count(char *log_path, char *level, char *key_word TSRMLS_DC);
-int get_detail(char *log_path, char *level, char *key_word, long start, long end, long order, zval *return_value TSRMLS_DC);
+long get_type_count(char *log_path, char *level, char *key_word );
+int get_detail(char *log_path, char *level, char *key_word, long start, long end, long order, zval *return_value );
 
 #endif /* _SEASLOG_ANALYZER_H_ */
 

--- a/include/Appender.h
+++ b/include/Appender.h
@@ -19,9 +19,9 @@
 
 #include "php_seaslog.h"
 
-int seaslog_log_context(int argc, char *level, int level_int, char *message, int message_len, HashTable *context, char *module, int module_len, zend_class_entry *ce TSRMLS_DC);
-int seaslog_log_ex(int argc, char *level, int level_int, char *message, int message_len, char *module, int module_len, zend_class_entry *ce TSRMLS_DC);
-int make_log_dir(char *dir TSRMLS_DC);
+int seaslog_log_context(int argc, char *level, int level_int, char *message, int message_len, HashTable *context, char *module, int module_len, zend_class_entry *ce );
+int seaslog_log_ex(int argc, char *level, int level_int, char *message, int message_len, char *module, int module_len, zend_class_entry *ce );
+int make_log_dir(char *dir );
 
 #endif /* _SEASLOG_APPENDER_H_ */
 

--- a/include/Buffer.h
+++ b/include/Buffer.h
@@ -19,12 +19,12 @@
 
 #include "php_seaslog.h"
 
-void init_buffer_switch(TSRMLS_D);
-void seaslog_init_buffer(TSRMLS_D);
-void seaslog_shutdown_buffer(int re_init TSRMLS_DC);
-void seaslog_clear_buffer(TSRMLS_D);
-int seaslog_check_buffer_enable(TSRMLS_D);
-int seaslog_buffer_set(char *log_info, int log_info_len, char *path, int path_len, zend_class_entry *ce TSRMLS_DC);
+void init_buffer_switch(void);
+void seaslog_init_buffer(void);
+void seaslog_shutdown_buffer(int re_init );
+void seaslog_clear_buffer(void);
+int seaslog_check_buffer_enable(void);
+int seaslog_buffer_set(char *log_info, int log_info_len, char *path, int path_len, zend_class_entry *ce );
 
 #endif /* _SEASLOG_BUFFER_H_ */
 

--- a/include/Common.h
+++ b/include/Common.h
@@ -21,11 +21,11 @@
 
 int seaslog_smart_str_get_len(smart_str str);
 
-int check_sapi_is_cli(TSRMLS_D);
-int check_log_level(int level TSRMLS_DC);
+int check_sapi_is_cli(void);
+int check_log_level(int level );
 int seaslog_get_level_int(char *level);
 char *str_replace(char *src, const char *from, const char *to);
-int message_trim_wrap(char *message,int message_len TSRMLS_DC);
+int message_trim_wrap(char *message,int message_len );
 
 char* delN(char *a);
 char* get_uniqid();

--- a/include/Datetime.h
+++ b/include/Datetime.h
@@ -19,14 +19,14 @@
 
 #include "php_seaslog.h"
 
-char *make_real_time(TSRMLS_D);
-void init_remote_timeout(TSRMLS_D);
-char *seaslog_process_last_sec(int now, int if_first TSRMLS_DC);
+char *make_real_time(void);
+void init_remote_timeout(void);
+char *seaslog_process_last_sec(int now, int if_first );
 void mic_time(smart_str *buf);
-char *make_time_RFC3339(TSRMLS_D);
-char *make_real_date(TSRMLS_D);
-char *make_real_time(TSRMLS_D);
-char *seaslog_process_last_min(int now, int if_first TSRMLS_DC);
+char *make_time_RFC3339(void);
+char *make_real_date(void);
+char *make_real_time(void);
+char *seaslog_process_last_min(int now, int if_first );
 
 #endif /* _SEASLOG_DATETIME_H_ */
 

--- a/include/ErrorHook.h
+++ b/include/ErrorHook.h
@@ -19,8 +19,8 @@
 
 #include "php_seaslog.h"
 
-void init_error_hooks(TSRMLS_D);
-void recovery_error_hooks(TSRMLS_D);
+void init_error_hooks(void);
+void recovery_error_hooks(void);
 
 #endif /* _SEASLOG_ERRORHOOK_H_ */
 

--- a/include/ExceptionHook.h
+++ b/include/ExceptionHook.h
@@ -19,10 +19,10 @@
 
 #include "php_seaslog.h"
 
-void seaslog_throw_exception(int type TSRMLS_DC, const char *format, ...);
-void init_exception_hooks(TSRMLS_D);
-void recovery_exception_hooks(TSRMLS_D);
-void seaslog_throw_exception_hook(zval *exception TSRMLS_DC);
+void seaslog_throw_exception(int type , const char *format, ...);
+void init_exception_hooks(void);
+void recovery_exception_hooks(void);
+void seaslog_throw_exception_hook(zval *exception );
 
 #endif /* _SEASLOG_EXCEPTIONHOOK_H_ */
 

--- a/include/Logger.h
+++ b/include/Logger.h
@@ -19,15 +19,15 @@
 
 #include "php_seaslog.h"
 
-void seaslog_init_slash_or_underline(TSRMLS_D);
-void seaslog_init_last_time(TSRMLS_D);
-void seaslog_init_logger_list(TSRMLS_D);
-void seaslog_init_logger(TSRMLS_D);
-void seaslog_clear_logger(TSRMLS_D);
-void seaslog_clear_logger_list(TSRMLS_D);
-void seaslog_clear_last_time(TSRMLS_D);
-void seaslog_init_default_last_logger(TSRMLS_D);
-logger_entry_t *process_logger(char *logger, int logger_len, int last_or_tmp TSRMLS_DC);
+void seaslog_init_slash_or_underline(void);
+void seaslog_init_last_time(void);
+void seaslog_init_logger_list(void);
+void seaslog_init_logger(void);
+void seaslog_clear_logger(void);
+void seaslog_clear_logger_list(void);
+void seaslog_clear_last_time(void);
+void seaslog_init_default_last_logger(void);
+logger_entry_t *process_logger(char *logger, int logger_len, int last_or_tmp );
 
 #endif /* _SEASLOG_LOGGER_H_ */
 

--- a/include/Performance.h
+++ b/include/Performance.h
@@ -19,29 +19,29 @@
 
 #include "php_seaslog.h"
 
-void seaslog_memory_usage(smart_str *buf TSRMLS_DC);
-void seaslog_peak_memory_usage(smart_str *buf TSRMLS_DC);
+void seaslog_memory_usage(smart_str *buf );
+void seaslog_peak_memory_usage(smart_str *buf );
 
-void init_zend_hooks(TSRMLS_D);
-void recovery_zend_hooks(TSRMLS_D);
+void init_zend_hooks(void);
+void recovery_zend_hooks(void);
 
-void seaslog_rinit_performance(TSRMLS_D);
-void seaslog_clear_performance(zend_class_entry *ce TSRMLS_DC);
-int seaslog_check_performance_active(TSRMLS_D);
+void seaslog_rinit_performance(void);
+void seaslog_clear_performance(zend_class_entry *ce );
+int seaslog_check_performance_active(void);
 
-int performance_frame_begin(zend_execute_data *execute_data TSRMLS_DC);
-void performance_frame_end(TSRMLS_D);
+int performance_frame_begin(zend_execute_data *execute_data );
+void performance_frame_end(void);
 
-seaslog_frame* seaslog_performance_fast_alloc_frame(TSRMLS_D);
-void seaslog_performance_fast_free_frame(seaslog_frame *p TSRMLS_DC);
-void seaslog_performance_free_the_free_list(TSRMLS_D);
+seaslog_frame* seaslog_performance_fast_alloc_frame(void);
+void seaslog_performance_fast_free_frame(seaslog_frame *p );
+void seaslog_performance_free_the_free_list(void);
 
-void seaslog_performance_bucket_free(seaslog_performance_bucket *bucket TSRMLS_DC);
+void seaslog_performance_bucket_free(seaslog_performance_bucket *bucket );
 
-char* seaslog_performance_get_class_name(zend_execute_data *data TSRMLS_DC);
-char* seaslog_performance_get_function_name(zend_execute_data *data TSRMLS_DC);
+char* seaslog_performance_get_class_name(zend_execute_data *data );
+char* seaslog_performance_get_function_name(zend_execute_data *data );
 
-int process_seaslog_performance_log(zend_class_entry *ce TSRMLS_DC);
-int process_seaslog_performance_clear(TSRMLS_D);
+int process_seaslog_performance_log(zend_class_entry *ce );
+int process_seaslog_performance_clear(void);
 #endif /* _SEASLOG_PERFORMANCE_H_ */
 

--- a/include/Request.h
+++ b/include/Request.h
@@ -19,16 +19,16 @@
 
 #include "php_seaslog.h"
 
-void seaslog_init_pid(TSRMLS_D);
-void seaslog_init_host_name(TSRMLS_D);
-void seaslog_init_request_id(TSRMLS_D);
-void seaslog_init_auto_globals(TSRMLS_D);
-int seaslog_init_request_variable(TSRMLS_D);
-void seaslog_clear_request_id(TSRMLS_D);
-void seaslog_clear_pid(TSRMLS_D);
-void seaslog_clear_host_name(TSRMLS_D);
-void seaslog_clear_request_variable(TSRMLS_D);
-void get_code_filename_line(smart_str *result TSRMLS_DC);
+void seaslog_init_pid(void);
+void seaslog_init_host_name(void);
+void seaslog_init_request_id(void);
+void seaslog_init_auto_globals(void);
+int seaslog_init_request_variable(void);
+void seaslog_clear_request_id(void);
+void seaslog_clear_pid(void);
+void seaslog_clear_host_name(void);
+void seaslog_clear_request_variable(void);
+void get_code_filename_line(smart_str *result );
 
 #endif /* _SEASLOG_REQUEST_H_ */
 

--- a/include/StreamWrapper.h
+++ b/include/StreamWrapper.h
@@ -19,9 +19,9 @@
 
 #include "php_seaslog.h"
 
-void seaslog_init_stream_list(TSRMLS_D);
-int seaslog_clear_stream(int destroy, int model, char *opt TSRMLS_DC);
-php_stream *process_stream(char *opt, int opt_len TSRMLS_DC);
+void seaslog_init_stream_list(void);
+int seaslog_clear_stream(int destroy, int model, char *opt );
+php_stream *process_stream(char *opt, int opt_len );
 
 #endif /* _SEASLOG_STREAMWRAPPER_H_ */
 

--- a/include/TemplateFormatter.h
+++ b/include/TemplateFormatter.h
@@ -19,11 +19,11 @@
 
 #include "php_seaslog.h"
 
-void seaslog_init_template(TSRMLS_D);
-void seaslog_re_init_template(TSRMLS_D);
-void seaslog_clear_template(TSRMLS_D);
-int seaslog_spprintf(char **pbuf TSRMLS_DC, int generate_type, char *level, size_t max_len, ...);
-void seaslog_template_formatter(smart_str *xbuf TSRMLS_DC, int generate_type, const char *fmt, char *level, va_list ap);
+void seaslog_init_template(void);
+void seaslog_re_init_template(void);
+void seaslog_clear_template(void);
+int seaslog_spprintf(char **pbuf , int generate_type, char *level, size_t max_len, ...);
+void seaslog_template_formatter(smart_str *xbuf , int generate_type, const char *fmt, char *level, va_list ap);
 
 #endif /* _SEASLOG_TEMPLATEFORMATTER_H_ */
 

--- a/include/php7_wrapper.h
+++ b/include/php7_wrapper.h
@@ -51,7 +51,7 @@ typedef uint SEASLOG_UINT;
 # define SEASLOG_ZEND_HASH_INDEX_UPDATE(ht, h, pData, nDataSize, pDest)  zend_hash_index_update_ptr(ht, h, pData)
 # define SEASLOG_SMART_STR_C(str) ZSTR_VAL(str.s)
 # define SEASLOG_SMART_STR_L(str) ZSTR_LEN(str.s)
-# define SEASLOG_AUTO_GLOBAL(n) zend_is_auto_global_str(ZEND_STRL(n) TSRMLS_CC)
+# define SEASLOG_AUTO_GLOBAL(n) zend_is_auto_global_str(ZEND_STRL(n) )
 # define SEASLOG_ZVAL_PTR_DTOR(z) zval_ptr_dtor(z)
 
 # define SEASLOG_ZEND_DECLARE_PROPERTY(ce, s, l, z, i) zend_declare_property(ce, s, l, z, i)
@@ -89,7 +89,7 @@ typedef uint SEASLOG_UINT;
 		} \
 	} while(0)
 
-# define SEASLOG_JSON_ENCODE(buf, zval, options) php_json_encode(buf, &zval, options TSRMLS_CC)
+# define SEASLOG_JSON_ENCODE(buf, zval, options) php_json_encode(buf, &zval, options )
 
 #else
 
@@ -115,29 +115,29 @@ typedef uint SEASLOG_UINT;
 # define SEASLOG_ZEND_HASH_INDEX_UPDATE(ht, h, pData, nDataSize, pDest)  zend_hash_index_update(ht, h, pData, nDataSize, pDest)
 # define SEASLOG_SMART_STR_C(str) str.c
 # define SEASLOG_SMART_STR_L(str) str.len
-# define SEASLOG_AUTO_GLOBAL(n) zend_is_auto_global(n, sizeof(n)-1 TSRMLS_CC)
+# define SEASLOG_AUTO_GLOBAL(n) zend_is_auto_global(n, sizeof(n)-1 )
 # define SEASLOG_ZVAL_PTR_DTOR(z) zval_ptr_dtor(&z)
 
-# define SEASLOG_ZEND_DECLARE_PROPERTY(ce, s, l, z, i) zend_declare_property(ce, s, l, z, i TSRMLS_CC)
-# define SEASLOG_ZEND_DECLARE_PROPERTY_EX(ce, zs, z, i, zdc) zend_declare_property_ex(ce, zs, z, i, zdc TSRMLS_CC)
-# define SEASLOG_ZEND_DECLARE_PROPERTY_NULL(ce, s, sl, i) zend_declare_property_null(ce, s, sl, i TSRMLS_CC)
-# define SEASLOG_ZEND_DECLARE_PROPERTY_BOOL(ce, s, sl, v, i) zend_declare_property_bool(ce, s, sl, v, i TSRMLS_CC)
-# define SEASLOG_ZEND_DECLARE_PROPERTY_LONG(ce, s, sl, lv, i) zend_declare_property_long(ce, s, sl, lv, i TSRMLS_CC)
-# define SEASLOG_ZEND_DECLARE_PROPERTY_DOUBLE(ce, s, sl, dv, i) zend_declare_property_double(ce, s, sl, dv, i TSRMLS_CC)
-# define SEASLOG_ZEND_DECLARE_PROPERTY_STRING(ce, s, sl, sv, i) zend_declare_property_string(ce, s, sl, sv, i TSRMLS_CC)
-# define SEASLOG_ZEND_DECLARE_PROPERTY_STRINGL(ce, s, sl, sv, svl, i) zend_declare_property_string(ce, s, sl, sv, svl, i TSRMLS_CC)
+# define SEASLOG_ZEND_DECLARE_PROPERTY(ce, s, l, z, i) zend_declare_property(ce, s, l, z, i )
+# define SEASLOG_ZEND_DECLARE_PROPERTY_EX(ce, zs, z, i, zdc) zend_declare_property_ex(ce, zs, z, i, zdc )
+# define SEASLOG_ZEND_DECLARE_PROPERTY_NULL(ce, s, sl, i) zend_declare_property_null(ce, s, sl, i )
+# define SEASLOG_ZEND_DECLARE_PROPERTY_BOOL(ce, s, sl, v, i) zend_declare_property_bool(ce, s, sl, v, i )
+# define SEASLOG_ZEND_DECLARE_PROPERTY_LONG(ce, s, sl, lv, i) zend_declare_property_long(ce, s, sl, lv, i )
+# define SEASLOG_ZEND_DECLARE_PROPERTY_DOUBLE(ce, s, sl, dv, i) zend_declare_property_double(ce, s, sl, dv, i )
+# define SEASLOG_ZEND_DECLARE_PROPERTY_STRING(ce, s, sl, sv, i) zend_declare_property_string(ce, s, sl, sv, i )
+# define SEASLOG_ZEND_DECLARE_PROPERTY_STRINGL(ce, s, sl, sv, svl, i) zend_declare_property_string(ce, s, sl, sv, svl, i )
 
-# define SEASLOG_ZEND_UPDATE_PROPERTY(ce, z, zl, zn) zend_update_property(ce, z, zl, zn TSRMLS_CC)
-# define SEASLOG_ZEND_UPDATE_PROPERTY_NULL(ce, z, zl) zend_update_property_null(ce, z, zl TSRMLS_CC)
-# define SEASLOG_ZEND_UPDATE_PROPERTY_EX(ce, z, zl, zn) zend_update_property_ex(ce, z, zl, zn TSRMLS_CC)
-# define SEASLOG_ZEND_UPDATE_STATIC_PROPERTY(ce, zl, zn) zend_update_static_property(ce, zl, zn TSRMLS_CC)
-# define SEASLOG_ZEND_UPDATE_PROPERTY_LONG(ce, z, zl, zn) zend_update_property_long(ce, z, zl, zn TSRMLS_CC)
-# define SEASLOG_ZEND_READ_PROPERTY(ce, z, sl)  zend_read_property(ce, z, sl, 1 TSRMLS_CC)
+# define SEASLOG_ZEND_UPDATE_PROPERTY(ce, z, zl, zn) zend_update_property(ce, z, zl, zn )
+# define SEASLOG_ZEND_UPDATE_PROPERTY_NULL(ce, z, zl) zend_update_property_null(ce, z, zl )
+# define SEASLOG_ZEND_UPDATE_PROPERTY_EX(ce, z, zl, zn) zend_update_property_ex(ce, z, zl, zn )
+# define SEASLOG_ZEND_UPDATE_STATIC_PROPERTY(ce, zl, zn) zend_update_static_property(ce, zl, zn )
+# define SEASLOG_ZEND_UPDATE_PROPERTY_LONG(ce, z, zl, zn) zend_update_property_long(ce, z, zl, zn )
+# define SEASLOG_ZEND_READ_PROPERTY(ce, z, sl)  zend_read_property(ce, z, sl, 1 )
 
 # if PHP_API_VERSION >= 20100412
-# define SEASLOG_EXPAND_FILE_PATH(dir, buf) expand_filepath_with_mode(dir, buf, NULL, 0, CWD_EXPAND TSRMLS_CC)
+# define SEASLOG_EXPAND_FILE_PATH(dir, buf) expand_filepath_with_mode(dir, buf, NULL, 0, CWD_EXPAND )
 # else
-# define SEASLOG_EXPAND_FILE_PATH(dir, buf) expand_filepath_ex(dir, buf, NULL, 0 TSRMLS_CC)
+# define SEASLOG_EXPAND_FILE_PATH(dir, buf) expand_filepath_ex(dir, buf, NULL, 0 )
 # endif
 
 # define STR_NAME_VAL(k) (char *)(estrdup(k))
@@ -156,9 +156,9 @@ typedef uint SEASLOG_UINT;
 	} while(0)
 
 # if PHP_VERSION_ID < 50300
-# define SEASLOG_JSON_ENCODE(buf, zval, options) php_json_encode(buf, zval TSRMLS_CC)
+# define SEASLOG_JSON_ENCODE(buf, zval, options) php_json_encode(buf, zval )
 # else
-# define SEASLOG_JSON_ENCODE(buf, zval, options) php_json_encode(buf, zval, options TSRMLS_CC)
+# define SEASLOG_JSON_ENCODE(buf, zval, options) php_json_encode(buf, zval, options )
 # endif
 
 #endif

--- a/seaslog.c
+++ b/seaslog.c
@@ -260,25 +260,25 @@ PHP_MINIT_FUNCTION(seaslog)
 #if PHP_VERSION_ID >= 70000
     seaslog_ce = zend_register_internal_class_ex(&seaslog, NULL);
 #else
-    seaslog_ce = zend_register_internal_class_ex(&seaslog, NULL, NULL TSRMLS_CC);
+    seaslog_ce = zend_register_internal_class_ex(&seaslog, NULL, NULL );
 #endif
 
     seaslog_ce->ce_flags |= ZEND_ACC_FINAL;
 
-    init_error_hooks(TSRMLS_C);
-    init_exception_hooks(TSRMLS_C);
-    init_buffer_switch(TSRMLS_C);
-    init_remote_timeout(TSRMLS_C);
-    init_zend_hooks(TSRMLS_C);
+    init_error_hooks();
+    init_exception_hooks();
+    init_buffer_switch();
+    init_remote_timeout();
+    init_zend_hooks();
 
     return SUCCESS;
 }
 
 PHP_MSHUTDOWN_FUNCTION(seaslog)
 {
-    recovery_error_hooks(TSRMLS_C);
-    recovery_exception_hooks(TSRMLS_C);
-    recovery_zend_hooks(TSRMLS_C);
+    recovery_error_hooks();
+    recovery_exception_hooks();
+    recovery_zend_hooks();
 
     UNREGISTER_INI_ENTRIES();
 
@@ -290,20 +290,20 @@ PHP_RINIT_FUNCTION(seaslog)
     SEASLOG_G(initRComplete) = SEASLOG_INITR_COMPLETE_NO;
     SEASLOG_G(error_loop) = 0;
 
-    seaslog_init_slash_or_underline(TSRMLS_C);
-    seaslog_init_pid(TSRMLS_C);
-    seaslog_init_host_name(TSRMLS_C);
-    seaslog_init_request_id(TSRMLS_C);
-    seaslog_init_auto_globals(TSRMLS_C);
-    seaslog_init_request_variable(TSRMLS_C);
-    seaslog_init_last_time(TSRMLS_C);
-    seaslog_init_template(TSRMLS_C);
-    seaslog_init_logger_list(TSRMLS_C);
-    seaslog_init_logger(TSRMLS_C);
-    seaslog_init_buffer(TSRMLS_C);
-    seaslog_init_stream_list(TSRMLS_C);
+    seaslog_init_slash_or_underline();
+    seaslog_init_pid();
+    seaslog_init_host_name();
+    seaslog_init_request_id();
+    seaslog_init_auto_globals();
+    seaslog_init_request_variable();
+    seaslog_init_last_time();
+    seaslog_init_template();
+    seaslog_init_logger_list();
+    seaslog_init_logger();
+    seaslog_init_buffer();
+    seaslog_init_stream_list();
 
-    seaslog_rinit_performance(TSRMLS_C);
+    seaslog_rinit_performance();
 
     SEASLOG_G(initRComplete) = SEASLOG_INITR_COMPLETE_YES;
     return SUCCESS;
@@ -311,18 +311,18 @@ PHP_RINIT_FUNCTION(seaslog)
 
 PHP_RSHUTDOWN_FUNCTION(seaslog)
 {
-    seaslog_clear_performance(seaslog_ce TSRMLS_CC);
-    seaslog_shutdown_buffer(SEASLOG_BUFFER_RE_INIT_NO TSRMLS_CC);
-    seaslog_clear_buffer(TSRMLS_C);
-    seaslog_clear_logger(TSRMLS_C);
-    seaslog_clear_logger_list(TSRMLS_C);
-    seaslog_clear_last_time(TSRMLS_C);
-    seaslog_clear_request_id(TSRMLS_C);
-    seaslog_clear_pid(TSRMLS_C);
-    seaslog_clear_host_name(TSRMLS_C);
-    seaslog_clear_template(TSRMLS_C);
-    seaslog_clear_request_variable(TSRMLS_C);
-    seaslog_clear_stream(SEASLOG_STREAM_LIST_DESTROY_YES, SEASLOG_CLOSE_LOGGER_STREAM_MOD_ALL, NULL TSRMLS_CC);
+    seaslog_clear_performance(seaslog_ce );
+    seaslog_shutdown_buffer(SEASLOG_BUFFER_RE_INIT_NO );
+    seaslog_clear_buffer();
+    seaslog_clear_logger();
+    seaslog_clear_logger_list();
+    seaslog_clear_last_time();
+    seaslog_clear_request_id();
+    seaslog_clear_pid();
+    seaslog_clear_host_name();
+    seaslog_clear_template();
+    seaslog_clear_request_variable();
+    seaslog_clear_stream(SEASLOG_STREAM_LIST_DESTROY_YES, SEASLOG_CLOSE_LOGGER_STREAM_MOD_ALL, NULL );
     return SUCCESS;
 }
 
@@ -370,18 +370,18 @@ zend_module_entry seaslog_module_entry =
     STANDARD_MODULE_PROPERTIES_EX
 };
 
-static inline int seaslog_log_context_ex(int argc, int check_argc, char *level, int level_int, char *message, int message_len, zval *context, char *module, int module_len, zend_class_entry *seaslog_ce TSRMLS_DC)
+static inline int seaslog_log_context_ex(int argc, int check_argc, char *level, int level_int, char *message, int message_len, zval *context, char *module, int module_len, zend_class_entry *seaslog_ce )
 {
     if (argc > check_argc)
     {
-        if (seaslog_log_context(argc, level, level_int, message, message_len, HASH_OF(context), module, module_len, seaslog_ce TSRMLS_CC) == FAILURE)
+        if (seaslog_log_context(argc, level, level_int, message, message_len, HASH_OF(context), module, module_len, seaslog_ce ) == FAILURE)
         {
             return FAILURE;
         }
     }
     else
     {
-        if (seaslog_log_ex(argc, level, level_int, message, message_len, "", 0, seaslog_ce TSRMLS_CC) == FAILURE)
+        if (seaslog_log_ex(argc, level, level_int, message, message_len, "", 0, seaslog_ce ) == FAILURE)
         {
             return FAILURE;
         }
@@ -390,7 +390,7 @@ static inline int seaslog_log_context_ex(int argc, int check_argc, char *level, 
     return SUCCESS;
 }
 
-static inline int seaslog_log_by_level_common_ex(int argc, int check_argc, char *level, int level_int, zval *messages, zval *context, char *logger_str, int logger_len, zend_class_entry *seaslog_ce TSRMLS_DC)
+static inline int seaslog_log_by_level_common_ex(int argc, int check_argc, char *level, int level_int, zval *messages, zval *context, char *logger_str, int logger_len, zend_class_entry *seaslog_ce )
 {
     HashTable *msght;
     zval *pzval;
@@ -408,7 +408,7 @@ static inline int seaslog_log_by_level_common_ex(int argc, int check_argc, char 
         ZEND_HASH_FOREACH_KEY_VAL(msght, num_key, str_key, pzval)
         {
             zend_string *s = zval_get_string(pzval);
-            if (FAILURE == seaslog_log_context_ex(argc, check_argc, level, level_int, ZSTR_VAL(s), ZSTR_LEN(s), context, logger_str, logger_len, seaslog_ce TSRMLS_CC))
+            if (FAILURE == seaslog_log_context_ex(argc, check_argc, level, level_int, ZSTR_VAL(s), ZSTR_LEN(s), context, logger_str, logger_len, seaslog_ce ))
             {
                 return FAILURE;
             }
@@ -421,7 +421,7 @@ static inline int seaslog_log_by_level_common_ex(int argc, int check_argc, char 
     default:
     {
         zend_string *s = zval_get_string(messages);
-        if (FAILURE == seaslog_log_context_ex(argc, check_argc, level, level_int, ZSTR_VAL(s), ZSTR_LEN(s), context, logger_str, logger_len, seaslog_ce TSRMLS_CC))
+        if (FAILURE == seaslog_log_context_ex(argc, check_argc, level, level_int, ZSTR_VAL(s), ZSTR_LEN(s), context, logger_str, logger_len, seaslog_ce ))
         {
             zend_string_release(s);
             return FAILURE;
@@ -442,7 +442,7 @@ static inline int seaslog_log_by_level_common_ex(int argc, int check_argc, char 
         while (zend_hash_get_current_data(msght, (void **)&ppzval) == SUCCESS)
         {
             convert_to_string_ex(ppzval);
-            if (FAILURE == seaslog_log_context_ex(argc, check_argc, level, level_int, Z_STRVAL_PP(ppzval), Z_STRLEN_PP(ppzval), context, logger_str, logger_len, seaslog_ce TSRMLS_CC))
+            if (FAILURE == seaslog_log_context_ex(argc, check_argc, level, level_int, Z_STRVAL_PP(ppzval), Z_STRLEN_PP(ppzval), context, logger_str, logger_len, seaslog_ce ))
             {
                 return FAILURE;
             }
@@ -453,7 +453,7 @@ static inline int seaslog_log_by_level_common_ex(int argc, int check_argc, char 
     case IS_STRING:
     default:
         convert_to_string_ex(&messages);
-        if (FAILURE == seaslog_log_context_ex(argc, check_argc, level, level_int, Z_STRVAL_P(messages), Z_STRLEN_P(messages), context, logger_str, logger_len, seaslog_ce TSRMLS_CC))
+        if (FAILURE == seaslog_log_context_ex(argc, check_argc, level, level_int, Z_STRVAL_P(messages), Z_STRLEN_P(messages), context, logger_str, logger_len, seaslog_ce ))
         {
             return FAILURE;
         }
@@ -464,17 +464,17 @@ static inline int seaslog_log_by_level_common_ex(int argc, int check_argc, char 
     return SUCCESS;
 }
 
-static inline int seaslog_log_by_level_common_check_context(int argc, int check_argc, zval *context TSRMLS_DC)
+static inline int seaslog_log_by_level_common_check_context(int argc, int check_argc, zval *context )
 {
     if (argc > check_argc && IS_ARRAY != Z_TYPE_P(context))
     {
         switch(check_argc)
         {
         case SEASLOG_LOG_FUNCTION_ARGC_USUAL:
-            php_error_docref(NULL TSRMLS_CC, E_WARNING, "The second argument is not an array");
+            php_error_docref(NULL , E_WARNING, "The second argument is not an array");
             break;
         case SEASLOG_LOG_FUNCTION_ARGC_UNUSUAL:
-            php_error_docref(NULL TSRMLS_CC, E_WARNING, "The three argument is not an array");
+            php_error_docref(NULL , E_WARNING, "The three argument is not an array");
             break;
         }
 
@@ -496,12 +496,12 @@ static void seaslog_log_by_level_common(INTERNAL_FUNCTION_PARAMETERS, char *leve
 #if PHP_VERSION_ID >= 70000
     zend_string *logger = NULL;
 
-    if (zend_parse_parameters(argc TSRMLS_CC, "z|zS", &messages, &context, &logger) == FAILURE)
+    if (zend_parse_parameters(argc , "z|zS", &messages, &context, &logger) == FAILURE)
     {
         return;
     }
 
-    if (FAILURE == seaslog_log_by_level_common_check_context(argc, SEASLOG_LOG_FUNCTION_ARGC_USUAL, context TSRMLS_CC))
+    if (FAILURE == seaslog_log_by_level_common_check_context(argc, SEASLOG_LOG_FUNCTION_ARGC_USUAL, context ))
     {
         RETURN_FALSE;
     }
@@ -512,24 +512,24 @@ static void seaslog_log_by_level_common(INTERNAL_FUNCTION_PARAMETERS, char *leve
         logger_len = ZSTR_LEN(logger);
     }
 
-    if (FAILURE == seaslog_log_by_level_common_ex(argc, SEASLOG_LOG_FUNCTION_ARGC_USUAL, level, level_int, messages, context, logger_str, logger_len, seaslog_ce TSRMLS_CC))
+    if (FAILURE == seaslog_log_by_level_common_ex(argc, SEASLOG_LOG_FUNCTION_ARGC_USUAL, level, level_int, messages, context, logger_str, logger_len, seaslog_ce ))
     {
         RETURN_FALSE;
     }
 
 #else
 
-    if (zend_parse_parameters(argc TSRMLS_CC, "z|zs", &messages, &context, &logger_str, &logger_len) == FAILURE)
+    if (zend_parse_parameters(argc , "z|zs", &messages, &context, &logger_str, &logger_len) == FAILURE)
     {
         return;
     }
 
-    if (FAILURE == seaslog_log_by_level_common_check_context(argc, SEASLOG_LOG_FUNCTION_ARGC_USUAL, context TSRMLS_CC))
+    if (FAILURE == seaslog_log_by_level_common_check_context(argc, SEASLOG_LOG_FUNCTION_ARGC_USUAL, context ))
     {
         RETURN_FALSE;
     }
 
-    if (FAILURE == seaslog_log_by_level_common_ex(argc, SEASLOG_LOG_FUNCTION_ARGC_USUAL, level, level_int, messages, context, logger_str, logger_len, seaslog_ce TSRMLS_CC))
+    if (FAILURE == seaslog_log_by_level_common_ex(argc, SEASLOG_LOG_FUNCTION_ARGC_USUAL, level, level_int, messages, context, logger_str, logger_len, seaslog_ce ))
     {
         RETURN_FALSE;
     }
@@ -562,7 +562,7 @@ PHP_METHOD(SEASLOG_RES_NAME, __construct)
 
 PHP_METHOD(SEASLOG_RES_NAME, __destruct)
 {
-    seaslog_shutdown_buffer(SEASLOG_BUFFER_RE_INIT_YES TSRMLS_CC);
+    seaslog_shutdown_buffer(SEASLOG_BUFFER_RE_INIT_YES );
     RETURN_TRUE;
 }
 
@@ -573,7 +573,7 @@ PHP_METHOD(SEASLOG_RES_NAME, setBasePath)
     zval *_base_path;
     int argc = ZEND_NUM_ARGS();
 
-    if (zend_parse_parameters(argc TSRMLS_CC, "z", &_base_path) == FAILURE)
+    if (zend_parse_parameters(argc , "z", &_base_path) == FAILURE)
     {
         return;
     }
@@ -586,7 +586,7 @@ PHP_METHOD(SEASLOG_RES_NAME, setBasePath)
 
             SEASLOG_G(base_path) = estrdup(Z_STRVAL_P(_base_path));
 
-            seaslog_init_default_last_logger(TSRMLS_C);
+            seaslog_init_default_last_logger();
         }
 
         RETURN_TRUE;
@@ -611,7 +611,7 @@ PHP_METHOD(SEASLOG_RES_NAME, setLogger)
     zval *_module;
     int argc = ZEND_NUM_ARGS();
 
-    if (zend_parse_parameters(argc TSRMLS_CC, "z", &_module) == FAILURE)
+    if (zend_parse_parameters(argc , "z", &_module) == FAILURE)
     {
         return;
     }
@@ -620,7 +620,7 @@ PHP_METHOD(SEASLOG_RES_NAME, setLogger)
     {
         if (strncmp(SEASLOG_G(last_logger)->logger,Z_STRVAL_P(_module),Z_STRLEN_P(_module) + 1))
         {
-            process_logger(Z_STRVAL_P(_module), Z_STRLEN_P(_module), SEASLOG_PROCESS_LOGGER_LAST TSRMLS_CC);
+            process_logger(Z_STRVAL_P(_module), Z_STRLEN_P(_module), SEASLOG_PROCESS_LOGGER_LAST );
         }
 
         RETURN_TRUE;
@@ -638,7 +638,7 @@ PHP_METHOD(SEASLOG_RES_NAME, closeLoggerStream)
     long model = 1;
     int argc = ZEND_NUM_ARGS();
 
-    if (zend_parse_parameters(argc TSRMLS_CC, "|lz", &model, &_module) == FAILURE)
+    if (zend_parse_parameters(argc , "|lz", &model, &_module) == FAILURE)
     {
         return;
     }
@@ -650,21 +650,21 @@ PHP_METHOD(SEASLOG_RES_NAME, closeLoggerStream)
 
     if (SEASLOG_CLOSE_LOGGER_STREAM_MOD_ALL == model)
     {
-        seaslog_shutdown_buffer(SEASLOG_BUFFER_RE_INIT_YES TSRMLS_CC);
-        seaslog_clear_stream(SEASLOG_STREAM_LIST_DESTROY_NO, SEASLOG_CLOSE_LOGGER_STREAM_MOD_ALL, NULL TSRMLS_CC);
+        seaslog_shutdown_buffer(SEASLOG_BUFFER_RE_INIT_YES );
+        seaslog_clear_stream(SEASLOG_STREAM_LIST_DESTROY_NO, SEASLOG_CLOSE_LOGGER_STREAM_MOD_ALL, NULL );
         RETURN_TRUE;
     }
 
     if (argc > 0 && SEASLOG_CLOSE_LOGGER_STREAM_MOD_ASSIGN == model && argc < 2)
     {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING, "With the first argument is SEASLOG_CLOSE_LOGGER_STREAM_MOD_ASSIGN, the second argument is required.");
+        php_error_docref(NULL , E_WARNING, "With the first argument is SEASLOG_CLOSE_LOGGER_STREAM_MOD_ASSIGN, the second argument is required.");
         RETURN_FALSE;
     }
 
     if (argc == 2 && (IS_STRING == Z_TYPE_P(_module) && Z_STRLEN_P(_module) > 0))
     {
-        seaslog_shutdown_buffer(SEASLOG_BUFFER_RE_INIT_YES TSRMLS_CC);
-        if (SUCCESS == seaslog_clear_stream(SEASLOG_STREAM_LIST_DESTROY_NO, SEASLOG_CLOSE_LOGGER_STREAM_MOD_ASSIGN, Z_STRVAL_P(_module) TSRMLS_CC))
+        seaslog_shutdown_buffer(SEASLOG_BUFFER_RE_INIT_YES );
+        if (SUCCESS == seaslog_clear_stream(SEASLOG_STREAM_LIST_DESTROY_NO, SEASLOG_CLOSE_LOGGER_STREAM_MOD_ASSIGN, Z_STRVAL_P(_module) ))
         {
             RETURN_TRUE;
         }
@@ -691,7 +691,7 @@ PHP_METHOD(SEASLOG_RES_NAME, setDatetimeFormat)
 
     int argc = ZEND_NUM_ARGS();
 
-    if (zend_parse_parameters(argc TSRMLS_CC, "z", &_format) == FAILURE)
+    if (zend_parse_parameters(argc , "z", &_format) == FAILURE)
     {
         return;
     }
@@ -706,7 +706,7 @@ PHP_METHOD(SEASLOG_RES_NAME, setDatetimeFormat)
         SEASLOG_G(current_datetime_format) = estrdup(Z_STRVAL_P(_format));
 
         now = (long)time(NULL);
-        seaslog_process_last_sec(now, SEASLOG_INIT_FIRST_NO TSRMLS_CC);
+        seaslog_process_last_sec(now, SEASLOG_INIT_FIRST_NO );
 
 #if PHP_VERSION_ID >= 70000
         zval_ptr_dtor(_format);
@@ -735,7 +735,7 @@ PHP_METHOD(SEASLOG_RES_NAME, setRequestID)
     zval *_request_id;
     int argc = ZEND_NUM_ARGS();
 
-    if (zend_parse_parameters(argc TSRMLS_CC, "z", &_request_id) == FAILURE)
+    if (zend_parse_parameters(argc , "z", &_request_id) == FAILURE)
     {
         return;
     }
@@ -786,7 +786,7 @@ PHP_METHOD(SEASLOG_RES_NAME, setRequestVariable)
     long key = 0;
     int argc = ZEND_NUM_ARGS();
 
-    if (zend_parse_parameters(argc TSRMLS_CC, "lz", &key, &value) == FAILURE)
+    if (zend_parse_parameters(argc , "lz", &key, &value) == FAILURE)
     {
         return;
     }
@@ -830,7 +830,7 @@ PHP_METHOD(SEASLOG_RES_NAME, setRequestVariable)
         RETURN_FALSE;
     }
 
-    seaslog_re_init_template(TSRMLS_C);
+    seaslog_re_init_template();
 
     RETURN_TRUE;
 }
@@ -843,7 +843,7 @@ PHP_METHOD(SEASLOG_RES_NAME, getRequestVariable)
     long key = 0;
     int argc = ZEND_NUM_ARGS();
 
-    if (zend_parse_parameters(argc TSRMLS_CC, "l", &key) == FAILURE)
+    if (zend_parse_parameters(argc , "l", &key) == FAILURE)
     {
         return;
     }
@@ -887,7 +887,7 @@ PHP_METHOD(SEASLOG_RES_NAME, analyzerCount)
     zend_string *_level = NULL;
     zend_string *_key_word = NULL;
 
-    if (zend_parse_parameters(argc TSRMLS_CC, "|SSS", &_level, &_log_path, &_key_word) == FAILURE)
+    if (zend_parse_parameters(argc , "|SSS", &_level, &_log_path, &_key_word) == FAILURE)
     {
         return;
     }
@@ -918,7 +918,7 @@ PHP_METHOD(SEASLOG_RES_NAME, analyzerCount)
 
 #else
 
-    if (zend_parse_parameters(argc TSRMLS_CC, "|sss", &level, &level_len, &log_path, &log_path_len, &key_word, &key_word_len) == FAILURE)
+    if (zend_parse_parameters(argc , "|sss", &level, &level_len, &log_path, &log_path_len, &key_word, &key_word_len) == FAILURE)
     {
         return;
     }
@@ -935,14 +935,14 @@ PHP_METHOD(SEASLOG_RES_NAME, analyzerCount)
         long count_debug, count_info, count_notice, count_warn, count_error, count_critical, count_alert, count_emergency;
         array_init(return_value);
 
-        count_debug     = get_type_count(log_path, SEASLOG_DEBUG, key_word TSRMLS_CC);
-        count_info      = get_type_count(log_path, SEASLOG_INFO, key_word TSRMLS_CC);
-        count_notice    = get_type_count(log_path, SEASLOG_NOTICE, key_word TSRMLS_CC);
-        count_warn      = get_type_count(log_path, SEASLOG_WARNING, key_word TSRMLS_CC);
-        count_error     = get_type_count(log_path, SEASLOG_ERROR, key_word TSRMLS_CC);
-        count_critical  = get_type_count(log_path, SEASLOG_CRITICAL, key_word TSRMLS_CC);
-        count_alert     = get_type_count(log_path, SEASLOG_ALERT, key_word TSRMLS_CC);
-        count_emergency = get_type_count(log_path, SEASLOG_EMERGENCY, key_word TSRMLS_CC);
+        count_debug     = get_type_count(log_path, SEASLOG_DEBUG, key_word );
+        count_info      = get_type_count(log_path, SEASLOG_INFO, key_word );
+        count_notice    = get_type_count(log_path, SEASLOG_NOTICE, key_word );
+        count_warn      = get_type_count(log_path, SEASLOG_WARNING, key_word );
+        count_error     = get_type_count(log_path, SEASLOG_ERROR, key_word );
+        count_critical  = get_type_count(log_path, SEASLOG_CRITICAL, key_word );
+        count_alert     = get_type_count(log_path, SEASLOG_ALERT, key_word );
+        count_emergency = get_type_count(log_path, SEASLOG_EMERGENCY, key_word );
 
         add_assoc_long(return_value, SEASLOG_DEBUG, count_debug);
         add_assoc_long(return_value, SEASLOG_INFO, count_info);
@@ -955,7 +955,7 @@ PHP_METHOD(SEASLOG_RES_NAME, analyzerCount)
     }
     else
     {
-        count = get_type_count(log_path, level, key_word TSRMLS_CC);
+        count = get_type_count(log_path, level, key_word );
 
         RETURN_LONG(count);
     }
@@ -980,7 +980,7 @@ PHP_METHOD(SEASLOG_RES_NAME, analyzerDetail)
     zend_string *_level = NULL;
     zend_string *_key_word = NULL;
 
-    if (zend_parse_parameters(argc TSRMLS_CC, "S|SSlll", &_level, &_log_path, &_key_word, &start, &limit, &order) == FAILURE)
+    if (zend_parse_parameters(argc , "S|SSlll", &_level, &_log_path, &_key_word, &start, &limit, &order) == FAILURE)
     {
         return;
     }
@@ -992,7 +992,7 @@ PHP_METHOD(SEASLOG_RES_NAME, analyzerDetail)
     else if (argc > 3)
     {
 #ifdef WINDOWS
-        seaslog_throw_exception(SEASLOG_EXCEPTION_WINDOWS_ERROR TSRMLS_CC, "%s", "Param start and limit don't support Windows");
+        seaslog_throw_exception(SEASLOG_EXCEPTION_WINDOWS_ERROR , "%s", "Param start and limit don't support Windows");
         RETURN_FALSE;
 #endif
     }
@@ -1018,7 +1018,7 @@ PHP_METHOD(SEASLOG_RES_NAME, analyzerDetail)
 
 #else
 
-    if (zend_parse_parameters(argc TSRMLS_CC, "s|sslll", &level, &level_len, &log_path, &log_path_len, &key_word, &key_word_len, &start, &limit, &order) == FAILURE)
+    if (zend_parse_parameters(argc , "s|sslll", &level, &level_len, &log_path, &log_path_len, &key_word, &key_word_len, &start, &limit, &order) == FAILURE)
     {
         return;
     }
@@ -1030,7 +1030,7 @@ PHP_METHOD(SEASLOG_RES_NAME, analyzerDetail)
     else if (argc > 3)
     {
 #ifdef WINDOWS
-        seaslog_throw_exception(SEASLOG_EXCEPTION_WINDOWS_ERROR TSRMLS_CC, "%s", "Param start and limit don't support Windows");
+        seaslog_throw_exception(SEASLOG_EXCEPTION_WINDOWS_ERROR , "%s", "Param start and limit don't support Windows");
         RETURN_FALSE;
 #endif
     }
@@ -1045,7 +1045,7 @@ PHP_METHOD(SEASLOG_RES_NAME, analyzerDetail)
     }
 
 #endif
-    get_detail(log_path, level, key_word, start, start + limit - 1, order, return_value TSRMLS_CC);
+    get_detail(log_path, level, key_word, start, start + limit - 1, order, return_value );
 }
 /* }}} */
 
@@ -1053,7 +1053,7 @@ PHP_METHOD(SEASLOG_RES_NAME, analyzerDetail)
    Get the logs buffer in memory as array */
 PHP_METHOD(SEASLOG_RES_NAME, getBuffer)
 {
-    if (seaslog_check_buffer_enable(TSRMLS_C))
+    if (seaslog_check_buffer_enable())
     {
 #if PHP_VERSION_ID >= 70000
         RETURN_ZVAL(&SEASLOG_G(buffer), 1, 0);
@@ -1070,7 +1070,7 @@ PHP_METHOD(SEASLOG_RES_NAME, getBuffer)
    Get buffer enabled by use_buffer & buffer_disabled_in_cli & buffer_size as bool */
 PHP_METHOD(SEASLOG_RES_NAME, getBufferEnabled)
 {
-    if (seaslog_check_buffer_enable(TSRMLS_C))
+    if (seaslog_check_buffer_enable())
     {
         RETURN_TRUE;
     }
@@ -1085,7 +1085,7 @@ PHP_METHOD(SEASLOG_RES_NAME, getBufferEnabled)
    Get buffer count by use_buffer & buffer_disabled_in_cli & buffer_count as int */
 PHP_METHOD(SEASLOG_RES_NAME, getBufferCount)
 {
-    if(seaslog_check_buffer_enable(TSRMLS_C))
+    if(seaslog_check_buffer_enable())
     {
         RETURN_LONG(SEASLOG_G(buffer_count));
     }
@@ -1102,16 +1102,16 @@ PHP_METHOD(SEASLOG_RES_NAME, flushBuffer)
     long type = 1;
     int argc = ZEND_NUM_ARGS();
 
-    if (zend_parse_parameters(argc TSRMLS_CC, "|l", &type) == FAILURE)
+    if (zend_parse_parameters(argc , "|l", &type) == FAILURE)
     {
         return;
     }
 
     if(type == 0){
-        seaslog_clear_buffer(TSRMLS_C);
-        seaslog_init_buffer(TSRMLS_C);
+        seaslog_clear_buffer();
+        seaslog_init_buffer();
     }else{
-        seaslog_shutdown_buffer(SEASLOG_BUFFER_RE_INIT_YES TSRMLS_CC);
+        seaslog_shutdown_buffer(SEASLOG_BUFFER_RE_INIT_YES );
     }
     
 
@@ -1138,12 +1138,12 @@ PHP_METHOD(SEASLOG_RES_NAME, log)
     zend_string *level;
     zend_string *logger = NULL;
 
-    if (zend_parse_parameters(argc TSRMLS_CC, "Sz|zS", &level, &messages, &context, &logger) == FAILURE)
+    if (zend_parse_parameters(argc , "Sz|zS", &level, &messages, &context, &logger) == FAILURE)
     {
         return;
     }
 
-    if (FAILURE == seaslog_log_by_level_common_check_context(argc, SEASLOG_LOG_FUNCTION_ARGC_UNUSUAL, context TSRMLS_CC))
+    if (FAILURE == seaslog_log_by_level_common_check_context(argc, SEASLOG_LOG_FUNCTION_ARGC_UNUSUAL, context ))
     {
         RETURN_FALSE;
     }
@@ -1156,7 +1156,7 @@ PHP_METHOD(SEASLOG_RES_NAME, log)
         logger_len = ZSTR_LEN(logger);
     }
 
-    if (FAILURE == seaslog_log_by_level_common_ex(argc, SEASLOG_LOG_FUNCTION_ARGC_UNUSUAL, ZSTR_VAL(level), level_int, messages, context, logger_str, logger_len, seaslog_ce TSRMLS_CC))
+    if (FAILURE == seaslog_log_by_level_common_ex(argc, SEASLOG_LOG_FUNCTION_ARGC_UNUSUAL, ZSTR_VAL(level), level_int, messages, context, logger_str, logger_len, seaslog_ce ))
     {
         RETURN_FALSE;
     }
@@ -1165,19 +1165,19 @@ PHP_METHOD(SEASLOG_RES_NAME, log)
     char *level;
     int level_len = 0;
 
-    if (zend_parse_parameters(argc TSRMLS_CC, "sz|zs", &level, &level_len, &messages, &context, &logger_str, &logger_len) == FAILURE)
+    if (zend_parse_parameters(argc , "sz|zs", &level, &level_len, &messages, &context, &logger_str, &logger_len) == FAILURE)
     {
         return;
     }
 
-    if (FAILURE == seaslog_log_by_level_common_check_context(argc, SEASLOG_LOG_FUNCTION_ARGC_UNUSUAL, context TSRMLS_CC))
+    if (FAILURE == seaslog_log_by_level_common_check_context(argc, SEASLOG_LOG_FUNCTION_ARGC_UNUSUAL, context ))
     {
         RETURN_FALSE;
     }
 
     level_int = seaslog_get_level_int(level);
 
-    if (FAILURE == seaslog_log_by_level_common_ex(argc, SEASLOG_LOG_FUNCTION_ARGC_UNUSUAL, level, level_int, messages, context, logger_str, logger_len, seaslog_ce TSRMLS_CC))
+    if (FAILURE == seaslog_log_by_level_common_ex(argc, SEASLOG_LOG_FUNCTION_ARGC_UNUSUAL, level, level_int, messages, context, logger_str, logger_len, seaslog_ce ))
     {
         RETURN_FALSE;
     }

--- a/src/Analyzer.c
+++ b/src/Analyzer.c
@@ -19,7 +19,7 @@
 #include "ExceptionHook.h"
 #include "TemplateFormatter.h"
 
-long get_type_count(char *log_path, char *level, char *key_word TSRMLS_DC)
+long get_type_count(char *log_path, char *level, char *key_word )
 {
     FILE * fp;
     char buffer[BUFSIZ];
@@ -38,7 +38,7 @@ long get_type_count(char *log_path, char *level, char *key_word TSRMLS_DC)
     }
     else
     {
-        seaslog_spprintf(&level_template TSRMLS_CC, SEASLOG_GENERATE_LEVEL_TEMPLATE, level, 0);
+        seaslog_spprintf(&level_template , SEASLOG_GENERATE_LEVEL_TEMPLATE, level, 0);
     }
 
 
@@ -111,7 +111,7 @@ long get_type_count(char *log_path, char *level, char *key_word TSRMLS_DC)
 
     if (!fp)
     {
-        seaslog_throw_exception(SEASLOG_EXCEPTION_CONTENT_ERROR TSRMLS_CC, "Unable to fork [%s]", sh);
+        seaslog_throw_exception(SEASLOG_EXCEPTION_CONTENT_ERROR , "Unable to fork [%s]", sh);
         return -1;
     }
     else
@@ -131,7 +131,7 @@ long get_type_count(char *log_path, char *level, char *key_word TSRMLS_DC)
     return count;
 }
 
-int get_detail(char *log_path, char *level, char *key_word, long start, long end, long order, zval *return_value TSRMLS_DC)
+int get_detail(char *log_path, char *level, char *key_word, long start, long end, long order, zval *return_value )
 {
     FILE * fp;
     char buffer[SEASLOG_BUFFER_MAX_SIZE];
@@ -161,7 +161,7 @@ int get_detail(char *log_path, char *level, char *key_word, long start, long end
     }
     else
     {
-        seaslog_spprintf(&level_template TSRMLS_CC, SEASLOG_GENERATE_LEVEL_TEMPLATE, level, 0);
+        seaslog_spprintf(&level_template , SEASLOG_GENERATE_LEVEL_TEMPLATE, level, 0);
     }
 
     if (SEASLOG_G(disting_type))
@@ -244,7 +244,7 @@ int get_detail(char *log_path, char *level, char *key_word, long start, long end
 
     if (!fp)
     {
-        seaslog_throw_exception(SEASLOG_EXCEPTION_CONTENT_ERROR TSRMLS_CC, "Unable to fork [%s]", sh);
+        seaslog_throw_exception(SEASLOG_EXCEPTION_CONTENT_ERROR , "Unable to fork [%s]", sh);
 
         return FAILURE;
     }

--- a/src/Buffer.c
+++ b/src/Buffer.c
@@ -18,11 +18,11 @@
 #include "Common.h"
 #include "StreamWrapper.h"
 
-void init_buffer_switch(TSRMLS_D)
+void init_buffer_switch(void)
 {
     SEASLOG_G(enable_buffer_real) = FAILURE;
 
-    if (SUCCESS == check_sapi_is_cli(TSRMLS_C) && SEASLOG_G(buffer_disabled_in_cli))
+    if (SUCCESS == check_sapi_is_cli() && SEASLOG_G(buffer_disabled_in_cli))
     {
         return;
     }
@@ -36,16 +36,16 @@ void init_buffer_switch(TSRMLS_D)
     return;
 }
 
-int seaslog_check_buffer_enable(TSRMLS_D)
+int seaslog_check_buffer_enable(void)
 {
     return SUCCESS == SEASLOG_G(enable_buffer_real);
 }
 
-void seaslog_init_buffer(TSRMLS_D)
+void seaslog_init_buffer(void)
 {
     zval *z_buffer;
 
-    if (seaslog_check_buffer_enable(TSRMLS_C))
+    if (seaslog_check_buffer_enable())
     {
         SEASLOG_G(buffer_count) = 0;
 
@@ -65,7 +65,7 @@ void seaslog_init_buffer(TSRMLS_D)
     }
 }
 
-static int real_php_log_buffer(zval *msg_buffer, char *opt, int opt_len TSRMLS_DC)
+static int real_php_log_buffer(zval *msg_buffer, char *opt, int opt_len )
 {
     php_stream *stream = NULL;
     HashTable *ht;
@@ -78,7 +78,7 @@ static int real_php_log_buffer(zval *msg_buffer, char *opt, int opt_len TSRMLS_D
     zval **log;
 #endif
 
-    stream = process_stream(opt,opt_len TSRMLS_CC);
+    stream = process_stream(opt,opt_len );
 
     if (stream == NULL)
     {
@@ -111,7 +111,7 @@ static int real_php_log_buffer(zval *msg_buffer, char *opt, int opt_len TSRMLS_D
     return SUCCESS;
 }
 
-int seaslog_buffer_set(char *log_info, int log_info_len, char *path, int path_len, zend_class_entry *ce TSRMLS_DC)
+int seaslog_buffer_set(char *log_info, int log_info_len, char *path, int path_len, zend_class_entry *ce )
 {
 #if PHP_VERSION_ID >= 70000
 
@@ -184,14 +184,14 @@ int seaslog_buffer_set(char *log_info, int log_info_len, char *path, int path_le
 
         if (SEASLOG_G(buffer_count) >= SEASLOG_G(buffer_size))
         {
-            seaslog_shutdown_buffer(SEASLOG_BUFFER_RE_INIT_YES TSRMLS_CC);
+            seaslog_shutdown_buffer(SEASLOG_BUFFER_RE_INIT_YES );
         }
     }
 
     return SUCCESS;
 }
 
-void seaslog_shutdown_buffer(int re_init TSRMLS_DC)
+void seaslog_shutdown_buffer(int re_init )
 {
     HashTable   *ht;
 
@@ -203,7 +203,7 @@ void seaslog_shutdown_buffer(int re_init TSRMLS_DC)
     zval **ppzval;
 #endif
 
-    if (seaslog_check_buffer_enable(TSRMLS_C))
+    if (seaslog_check_buffer_enable())
     {
         if (SEASLOG_G(buffer_count) < 1)
         {
@@ -215,7 +215,7 @@ void seaslog_shutdown_buffer(int re_init TSRMLS_DC)
         ht = Z_ARRVAL(SEASLOG_G(buffer));
         ZEND_HASH_FOREACH_KEY_VAL(ht, num_key, str_key, entry)
         {
-            real_php_log_buffer(entry, ZSTR_VAL(str_key), ZSTR_LEN(str_key) TSRMLS_CC);
+            real_php_log_buffer(entry, ZSTR_VAL(str_key), ZSTR_LEN(str_key) );
         }
         ZEND_HASH_FOREACH_END();
 
@@ -230,23 +230,23 @@ void seaslog_shutdown_buffer(int re_init TSRMLS_DC)
 
             zend_hash_get_current_key(ht, &key, &idx, 0);
             convert_to_array_ex(ppzval);
-            real_php_log_buffer(*ppzval, key, strlen(key) TSRMLS_CC);
+            real_php_log_buffer(*ppzval, key, strlen(key) );
             zend_hash_move_forward(ht);
         }
 #endif
 
         if (re_init == SEASLOG_BUFFER_RE_INIT_YES)
         {
-            seaslog_clear_buffer(TSRMLS_C);
-            seaslog_init_buffer(TSRMLS_C);
+            seaslog_clear_buffer();
+            seaslog_init_buffer();
         }
     }
 }
 
 
-void seaslog_clear_buffer(TSRMLS_D)
+void seaslog_clear_buffer(void)
 {
-    if (seaslog_check_buffer_enable(TSRMLS_C))
+    if (seaslog_check_buffer_enable())
     {
         SEASLOG_G(buffer_count) = 0;
 

--- a/src/Common.c
+++ b/src/Common.c
@@ -25,7 +25,7 @@ int seaslog_smart_str_get_len(smart_str str)
 #endif
 }
 
-int check_sapi_is_cli(TSRMLS_D)
+int check_sapi_is_cli(void)
 {
     if (!strncmp(sapi_module.name , SEASLOG_CLI_KEY, sizeof(SEASLOG_CLI_KEY) - 1))
     {
@@ -73,7 +73,7 @@ int seaslog_get_level_int(char *level)
     return SEASLOG_DEBUG_INT;
 }
 
-int check_log_level(int level TSRMLS_DC)
+int check_log_level(int level )
 {
     if (level < SEASLOG_EMERGENCY_INT || level > SEASLOG_G(level))
     {
@@ -252,7 +252,7 @@ char* php_strtr_array(char *str, int slen, HashTable *hash)
 }
 #endif
 
-int message_trim_wrap(char *message,int message_len TSRMLS_DC)
+int message_trim_wrap(char *message,int message_len )
 {
     int i;
     for (i=0; i<message_len; i++)

--- a/src/Datetime.c
+++ b/src/Datetime.c
@@ -16,21 +16,21 @@
 
 #include "Datetime.h"
 
-static char *seaslog_format_date(char *format, int format_len, time_t ts TSRMLS_DC)
+static char *seaslog_format_date(char *format, int format_len, time_t ts )
 {
 #if PHP_VERSION_ID >= 70000
     zend_string *_date;
     char *_date_tmp;
-    _date = php_format_date(format, format_len, ts, 1 TSRMLS_CC);
+    _date = php_format_date(format, format_len, ts, 1 );
     _date_tmp = estrdup(ZSTR_VAL(_date));
     zend_string_release(_date);
     return _date_tmp;
 #else
-    return php_format_date(format, format_len, ts, 1 TSRMLS_CC);
+    return php_format_date(format, format_len, ts, 1 );
 #endif
 }
 
-void init_remote_timeout(TSRMLS_D)
+void init_remote_timeout(void)
 {
 #ifndef PHP_WIN32
     time_t conv;
@@ -51,7 +51,7 @@ void init_remote_timeout(TSRMLS_D)
     SEASLOG_G(remote_timeout_real) = tv;
 }
 
-char *seaslog_process_last_sec(int now, int if_first TSRMLS_DC)
+char *seaslog_process_last_sec(int now, int if_first )
 {
     if (SEASLOG_INIT_FIRST_YES == if_first)
     {
@@ -63,12 +63,12 @@ char *seaslog_process_last_sec(int now, int if_first TSRMLS_DC)
     }
 
     SEASLOG_G(last_sec)->sec = now;
-    SEASLOG_G(last_sec)->real_time = seaslog_format_date(SEASLOG_G(current_datetime_format), SEASLOG_G(current_datetime_format_len), now TSRMLS_CC);
+    SEASLOG_G(last_sec)->real_time = seaslog_format_date(SEASLOG_G(current_datetime_format), SEASLOG_G(current_datetime_format_len), now );
 
     return SEASLOG_G(last_sec)->real_time;
 }
 
-char *seaslog_process_last_min(int now, int if_first TSRMLS_DC)
+char *seaslog_process_last_min(int now, int if_first )
 {
     if (SEASLOG_INIT_FIRST_YES == if_first)
     {
@@ -83,33 +83,33 @@ char *seaslog_process_last_min(int now, int if_first TSRMLS_DC)
 
     if (SEASLOG_G(disting_by_hour))
     {
-        SEASLOG_G(last_min)->real_time = seaslog_format_date("YmdH", 4, now TSRMLS_CC);
+        SEASLOG_G(last_min)->real_time = seaslog_format_date("YmdH", 4, now );
     }
     else
     {
-        SEASLOG_G(last_min)->real_time = seaslog_format_date("Ymd",  3, now TSRMLS_CC);
+        SEASLOG_G(last_min)->real_time = seaslog_format_date("Ymd",  3, now );
     }
 
     return SEASLOG_G(last_min)->real_time;
 }
 
-char *make_real_date(TSRMLS_D)
+char *make_real_date(void)
 {
     int now = (long)time(NULL);
     if (now > SEASLOG_G(last_min)->sec + 60)
     {
-        return seaslog_process_last_min(now, SEASLOG_INIT_FIRST_NO TSRMLS_CC);
+        return seaslog_process_last_min(now, SEASLOG_INIT_FIRST_NO );
     }
 
     return SEASLOG_G(last_min)->real_time;
 }
 
-char *make_real_time(TSRMLS_D)
+char *make_real_time(void)
 {
     int now = (long)time(NULL);
     if (now > SEASLOG_G(last_sec)->sec)
     {
-        return seaslog_process_last_sec(now, SEASLOG_INIT_FIRST_NO TSRMLS_CC);
+        return seaslog_process_last_sec(now, SEASLOG_INIT_FIRST_NO );
     }
 
     return SEASLOG_G(last_sec)->real_time;
@@ -129,13 +129,13 @@ void mic_time(smart_str *buf)
     smart_str_0(buf);
 }
 
-char *make_time_RFC3339(TSRMLS_D)
+char *make_time_RFC3339(void)
 {
     int now = (long)time(NULL);
-    return seaslog_format_date("Y-m-d\\TH:i:sP", 14, now TSRMLS_CC);
+    return seaslog_format_date("Y-m-d\\TH:i:sP", 14, now );
 }
 
-static struct timeval seaslog_get_remote_timeout(TSRMLS_D)
+static struct timeval seaslog_get_remote_timeout(void)
 {
     return SEASLOG_G(remote_timeout_real);
 }

--- a/src/ErrorHook.c
+++ b/src/ErrorHook.c
@@ -19,7 +19,7 @@
 
 void (*old_error_cb)(int type, const char *error_filename, const SEASLOG_UINT error_lineno, const char *format, va_list args);
 
-static void process_event_error(const char *event_type, int type, char * error_filename, SEASLOG_UINT error_lineno, char * msg TSRMLS_DC)
+static void process_event_error(const char *event_type, int type, char * error_filename, SEASLOG_UINT error_lineno, char * msg )
 {
     char *event_str;
     int event_str_len;
@@ -30,7 +30,7 @@ static void process_event_error(const char *event_type, int type, char * error_f
 
     event_str_len = spprintf(&event_str, 0, "%s - type:%d - file:%s - line:%d - msg:%s", event_type, type, error_filename, error_lineno, msg);
 
-    seaslog_log_ex(1, SEASLOG_CRITICAL, SEASLOG_CRITICAL_INT, event_str, event_str_len, NULL, 0, seaslog_ce TSRMLS_CC);
+    seaslog_log_ex(1, SEASLOG_CRITICAL, SEASLOG_CRITICAL_INT, event_str, event_str_len, NULL, 0, seaslog_ce );
     efree(event_str);
 
     SEASLOG_G(in_error) = 0;
@@ -38,7 +38,6 @@ static void process_event_error(const char *event_type, int type, char * error_f
 
 void seaslog_error_cb(int type, const char *error_filename, const SEASLOG_UINT error_lineno, const char *format, va_list args)
 {
-    TSRMLS_FETCH();
     if (SEASLOG_G(initRComplete) != SEASLOG_INITR_COMPLETE_YES)
     {
         return old_error_cb(type, error_filename, error_lineno, format, args);
@@ -61,21 +60,21 @@ void seaslog_error_cb(int type, const char *error_filename, const SEASLOG_UINT e
         {
             if (SEASLOG_G(trace_error))
             {
-                process_event_error("Error", type, (char *) error_filename, error_lineno, msg TSRMLS_CC);
+                process_event_error("Error", type, (char *) error_filename, error_lineno, msg );
             }
         }
         else if (type == E_WARNING || type == E_CORE_WARNING || type == E_COMPILE_WARNING || type == E_USER_WARNING)
         {
             if (SEASLOG_G(trace_warning))
             {
-                process_event_error("Warning", type, (char *) error_filename, error_lineno, msg TSRMLS_CC);
+                process_event_error("Warning", type, (char *) error_filename, error_lineno, msg );
             }
         }
         else if (type == E_NOTICE || type == E_USER_NOTICE || type == E_STRICT || type == E_DEPRECATED || type == E_USER_DEPRECATED)
         {
             if (SEASLOG_G(trace_notice))
             {
-                process_event_error("Notice", type, (char *) error_filename, error_lineno, msg TSRMLS_CC);
+                process_event_error("Notice", type, (char *) error_filename, error_lineno, msg );
             }
         }
 
@@ -85,13 +84,13 @@ void seaslog_error_cb(int type, const char *error_filename, const SEASLOG_UINT e
     old_error_cb(type, error_filename, error_lineno, format, args);
 }
 
-void init_error_hooks(TSRMLS_D)
+void init_error_hooks(void)
 {
     old_error_cb = zend_error_cb;
     zend_error_cb = seaslog_error_cb;
 }
 
-void recovery_error_hooks(TSRMLS_D)
+void recovery_error_hooks(void)
 {
     if (old_error_cb)
     {

--- a/src/ExceptionHook.c
+++ b/src/ExceptionHook.c
@@ -17,20 +17,20 @@
 #include "ExceptionHook.h"
 #include "Appender.h"
 
-static void (*old_throw_exception_hook)(zval *exception TSRMLS_DC);
+static void (*old_throw_exception_hook)(zval *exception );
 
-static void process_event_exception(int type, char * error_filename, SEASLOG_UINT error_lineno, char * msg TSRMLS_DC)
+static void process_event_exception(int type, char * error_filename, SEASLOG_UINT error_lineno, char * msg )
 {
     char *event_str;
     int event_str_len;
 
     event_str_len = spprintf(&event_str, 0, "Exception - type:%d - file:%s - line:%d - msg:%s", type, error_filename, error_lineno, msg);
 
-    seaslog_log_ex(1, SEASLOG_CRITICAL, SEASLOG_CRITICAL_INT, event_str, event_str_len, NULL, 0, seaslog_ce TSRMLS_CC);
+    seaslog_log_ex(1, SEASLOG_CRITICAL, SEASLOG_CRITICAL_INT, event_str, event_str_len, NULL, 0, seaslog_ce );
     efree(event_str);
 }
 
-void seaslog_throw_exception_hook(zval *exception TSRMLS_DC)
+void seaslog_throw_exception_hook(zval *exception )
 {
     zval *message, *file, *line, *code;
 #if PHP_VERSION_ID >= 70000
@@ -46,7 +46,7 @@ void seaslog_throw_exception_hook(zval *exception TSRMLS_DC)
 #if PHP_VERSION_ID >= 70000
     default_ce = Z_OBJCE_P(exception);
 #else
-    default_ce = zend_exception_get_default(TSRMLS_C);
+    default_ce = zend_exception_get_default();
 #endif
 
 #if PHP_VERSION_ID >= 70000
@@ -55,21 +55,21 @@ void seaslog_throw_exception_hook(zval *exception TSRMLS_DC)
     line = zend_read_property(default_ce, exception, "line", sizeof("line")-1, 0, &rv);
     code = zend_read_property(default_ce, exception, "code", sizeof("code")-1, 0, &rv);
 #else
-    message = zend_read_property(default_ce, exception, "message", sizeof("message")-1, 0 TSRMLS_CC);
-    file = zend_read_property(default_ce, exception, "file", sizeof("file")-1, 0 TSRMLS_CC);
-    line = zend_read_property(default_ce, exception, "line", sizeof("line")-1, 0 TSRMLS_CC);
-    code = zend_read_property(default_ce, exception, "code", sizeof("code")-1, 0 TSRMLS_CC);
+    message = zend_read_property(default_ce, exception, "message", sizeof("message")-1, 0 );
+    file = zend_read_property(default_ce, exception, "file", sizeof("file")-1, 0 );
+    line = zend_read_property(default_ce, exception, "line", sizeof("line")-1, 0 );
+    code = zend_read_property(default_ce, exception, "code", sizeof("code")-1, 0 );
 #endif
 
-    process_event_exception(Z_LVAL_P(code), Z_STRVAL_P(file), Z_LVAL_P(line), Z_STRVAL_P(message) TSRMLS_CC);
+    process_event_exception(Z_LVAL_P(code), Z_STRVAL_P(file), Z_LVAL_P(line), Z_STRVAL_P(message) );
 
     if (old_throw_exception_hook)
     {
-        old_throw_exception_hook(exception TSRMLS_CC);
+        old_throw_exception_hook(exception );
     }
 }
 
-void init_exception_hooks(TSRMLS_D)
+void init_exception_hooks(void)
 {
     if (SEASLOG_G(trace_exception))
     {
@@ -82,7 +82,7 @@ void init_exception_hooks(TSRMLS_D)
     }
 }
 
-void recovery_exception_hooks(TSRMLS_D)
+void recovery_exception_hooks(void)
 {
     if (SEASLOG_G(trace_exception))
     {
@@ -93,7 +93,7 @@ void recovery_exception_hooks(TSRMLS_D)
     }
 }
 
-void seaslog_throw_exception(int type TSRMLS_DC, const char *format, ...)
+void seaslog_throw_exception(int type , const char *format, ...)
 {
     va_list args;
     char *message = NULL;
@@ -108,7 +108,7 @@ void seaslog_throw_exception(int type TSRMLS_DC, const char *format, ...)
 
     if (!SEASLOG_G(ignore_warning))
     {
-        php_error_docref(NULL TSRMLS_CC, E_WARNING, "[SeasLog] %s", message);
+        php_error_docref(NULL , E_WARNING, "[SeasLog] %s", message);
     }
 
     if (SEASLOG_G(throw_exception)
@@ -124,7 +124,7 @@ void seaslog_throw_exception(int type TSRMLS_DC, const char *format, ...)
 #if PHP_VERSION_ID >= 70000
         zend_throw_exception_ex(NULL, type, "%s", message);
 #else
-        zend_throw_exception_ex(NULL, type TSRMLS_CC, "%s", message);
+        zend_throw_exception_ex(NULL, type , "%s", message);
 #endif
 
     }

--- a/src/Logger.c
+++ b/src/Logger.c
@@ -18,7 +18,7 @@
 #include "Datetime.h"
 #include "Appender.h"
 
-void seaslog_init_slash_or_underline(TSRMLS_D)
+void seaslog_init_slash_or_underline(void)
 {
     if (SEASLOG_G(disting_folder))
     {
@@ -30,7 +30,7 @@ void seaslog_init_slash_or_underline(TSRMLS_D)
     }
 }
 
-void seaslog_init_last_time(TSRMLS_D)
+void seaslog_init_last_time(void)
 {
     int now;
 
@@ -38,11 +38,11 @@ void seaslog_init_last_time(TSRMLS_D)
     SEASLOG_G(current_datetime_format_len)  = strlen(SEASLOG_G(current_datetime_format));
 
     now = (int)time(NULL);
-    seaslog_process_last_sec(now, SEASLOG_INIT_FIRST_YES TSRMLS_CC);
-    seaslog_process_last_min(now, SEASLOG_INIT_FIRST_YES TSRMLS_CC);
+    seaslog_process_last_sec(now, SEASLOG_INIT_FIRST_YES );
+    seaslog_process_last_min(now, SEASLOG_INIT_FIRST_YES );
 }
 
-void seaslog_clear_last_time(TSRMLS_D)
+void seaslog_clear_last_time(void)
 {
     if (SEASLOG_G(last_sec))
     {
@@ -62,18 +62,18 @@ void seaslog_clear_last_time(TSRMLS_D)
     }
 }
 
-void seaslog_init_logger(TSRMLS_D)
+void seaslog_init_logger(void)
 {
     SEASLOG_G(base_path) = estrdup(SEASLOG_G(default_basepath));
 
     SEASLOG_G(last_logger) = ecalloc(1,sizeof(logger_entry_t));
     SEASLOG_G(tmp_logger) = ecalloc(1,sizeof(logger_entry_t));
 
-    seaslog_init_default_last_logger(TSRMLS_C);
+    seaslog_init_default_last_logger();
 }
 
 
-void seaslog_init_default_last_logger(TSRMLS_D)
+void seaslog_init_default_last_logger(void)
 {
     if (SEASLOG_G(last_logger)->logger)
     {
@@ -93,7 +93,7 @@ void seaslog_init_default_last_logger(TSRMLS_D)
 
     if (SEASLOG_G(disting_folder))
     {
-        if (make_log_dir(SEASLOG_G(last_logger)->logger_path TSRMLS_CC) == SUCCESS)
+        if (make_log_dir(SEASLOG_G(last_logger)->logger_path ) == SUCCESS)
         {
             SEASLOG_G(last_logger)->logger_access = SUCCESS;
         }
@@ -104,7 +104,7 @@ void seaslog_init_default_last_logger(TSRMLS_D)
     }
     else
     {
-        if (make_log_dir(SEASLOG_G(base_path) TSRMLS_CC) == SUCCESS)
+        if (make_log_dir(SEASLOG_G(base_path) ) == SUCCESS)
         {
             SEASLOG_G(last_logger)->logger_access = SUCCESS;
         }
@@ -116,7 +116,7 @@ void seaslog_init_default_last_logger(TSRMLS_D)
 }
 
 
-void seaslog_clear_logger(TSRMLS_D)
+void seaslog_clear_logger(void)
 {
     if (SEASLOG_G(base_path))
     {
@@ -154,7 +154,7 @@ void seaslog_clear_logger(TSRMLS_D)
     }
 }
 
-void seaslog_init_logger_list(TSRMLS_D)
+void seaslog_init_logger_list(void)
 {
     zval *z_logger_list;
 
@@ -170,12 +170,12 @@ void seaslog_init_logger_list(TSRMLS_D)
 #endif
 }
 
-void seaslog_clear_logger_list(TSRMLS_D)
+void seaslog_clear_logger_list(void)
 {
     SEASLOG_ARRAY_DESTROY(SEASLOG_G(logger_list));
 }
 
-logger_entry_t *process_logger(char *logger, int logger_len, int last_or_tmp TSRMLS_DC)
+logger_entry_t *process_logger(char *logger, int logger_len, int last_or_tmp )
 {
     ulong logger_entry_hash = zend_inline_hash_func(logger, logger_len);
     logger_entry_t *logger_entry;
@@ -259,7 +259,7 @@ logger_entry_t *process_logger(char *logger, int logger_len, int last_or_tmp TSR
 
         if (SEASLOG_G(disting_folder))
         {
-            if (make_log_dir(logger_entry->logger_path TSRMLS_CC) == SUCCESS)
+            if (make_log_dir(logger_entry->logger_path ) == SUCCESS)
             {
                 logger_entry->logger_access = SUCCESS;
             }
@@ -278,7 +278,7 @@ logger_entry_t *process_logger(char *logger, int logger_len, int last_or_tmp TSR
                 folder_tmp[folder_len] = '\0';
                 logger_entry->folder = folder_tmp;
 
-                if (make_log_dir(logger_entry->folder TSRMLS_CC) == SUCCESS)
+                if (make_log_dir(logger_entry->folder ) == SUCCESS)
                 {
                     logger_entry->logger_access = SUCCESS;
                 }

--- a/src/Performance.c
+++ b/src/Performance.c
@@ -20,25 +20,25 @@
 #include "ext/json/php_json.h"
 
 #if PHP_VERSION_ID >= 70000
-ZEND_DLEXPORT void (*_clone_zend_execute_ex) (zend_execute_data *execute_data TSRMLS_DC);
+ZEND_DLEXPORT void (*_clone_zend_execute_ex) (zend_execute_data *execute_data );
 ZEND_DLEXPORT void (*_clone_zend_execute_internal) (zend_execute_data *execute_data, zval *return_value);
 
-ZEND_DLEXPORT void seaslog_execute_ex (zend_execute_data *execute_data TSRMLS_DC);
+ZEND_DLEXPORT void seaslog_execute_ex (zend_execute_data *execute_data );
 ZEND_DLEXPORT void seaslog_execute_internal(zend_execute_data *execute_data, zval *return_value);
 
 #elif PHP_VERSION_ID >= 50500
-ZEND_DLEXPORT void (*_clone_zend_execute_ex) (zend_execute_data *execute_data TSRMLS_DC);
-ZEND_DLEXPORT void (*_clone_zend_execute_internal) (zend_execute_data *data, struct _zend_fcall_info *fci, int ret TSRMLS_DC);
+ZEND_DLEXPORT void (*_clone_zend_execute_ex) (zend_execute_data *execute_data );
+ZEND_DLEXPORT void (*_clone_zend_execute_internal) (zend_execute_data *data, struct _zend_fcall_info *fci, int ret );
 
-ZEND_DLEXPORT void seaslog_execute_ex (zend_execute_data *execute_data TSRMLS_DC);
-ZEND_DLEXPORT void seaslog_execute_internal(zend_execute_data *execute_data, struct _zend_fcall_info *fci, int ret TSRMLS_DC);
+ZEND_DLEXPORT void seaslog_execute_ex (zend_execute_data *execute_data );
+ZEND_DLEXPORT void seaslog_execute_internal(zend_execute_data *execute_data, struct _zend_fcall_info *fci, int ret );
 
 #else
-ZEND_DLEXPORT void (*_clone_zend_execute) (zend_op_array *ops TSRMLS_DC);
-ZEND_DLEXPORT void (*_clone_zend_execute_internal) (zend_execute_data *data, int ret TSRMLS_DC);
+ZEND_DLEXPORT void (*_clone_zend_execute) (zend_op_array *ops );
+ZEND_DLEXPORT void (*_clone_zend_execute_internal) (zend_execute_data *data, int ret );
 
-ZEND_DLEXPORT void seaslog_execute (zend_op_array *ops TSRMLS_DC);
-ZEND_DLEXPORT void seaslog_execute_internal(zend_execute_data *execute_data, int ret TSRMLS_DC);
+ZEND_DLEXPORT void seaslog_execute (zend_op_array *ops );
+ZEND_DLEXPORT void seaslog_execute_internal(zend_execute_data *execute_data, int ret );
 #endif
 
 #define SEASLOG_PERFORMANCE_BUCKET_FOREACH(bucket, _i) do { \
@@ -52,7 +52,7 @@ ZEND_DLEXPORT void seaslog_execute_internal(zend_execute_data *execute_data, int
 	} while (0)
 
 
-static inline int seaslog_check_performance_sample(TSRMLS_D)
+static inline int seaslog_check_performance_sample(void)
 {
     if (SUCCESS == SEASLOG_G(trace_performance_sample_active))
     {
@@ -62,7 +62,7 @@ static inline int seaslog_check_performance_sample(TSRMLS_D)
     return FAILURE;
 }
 
-static inline int seaslog_process_performance_sample(TSRMLS_D)
+static inline int seaslog_process_performance_sample(void)
 {
     SEASLOG_G(trace_performance_sample_active) = FAILURE;
 
@@ -88,7 +88,7 @@ static inline long hash_data(long hash, char *data, size_t size)
     return hash;
 }
 
-static inline long performance_microsecond(TSRMLS_D)
+static inline long performance_microsecond(void)
 {
     struct timeval tv;
     gettimeofday(&tv, NULL);
@@ -99,23 +99,23 @@ static inline long performance_microsecond(TSRMLS_D)
     return val;
 }
 
-void seaslog_memory_usage(smart_str *buf TSRMLS_DC)
+void seaslog_memory_usage(smart_str *buf )
 {
-    long int usage = zend_memory_usage(0 TSRMLS_CC);
+    long int usage = zend_memory_usage(0 );
     smart_str_append_long(buf, usage);
 
     smart_str_0(buf);
 }
 
-void seaslog_peak_memory_usage(smart_str *buf TSRMLS_DC)
+void seaslog_peak_memory_usage(smart_str *buf )
 {
-    long int usage = zend_memory_peak_usage(0 TSRMLS_CC);
+    long int usage = zend_memory_peak_usage(0 );
     smart_str_append_long(buf, usage);
 
     smart_str_0(buf);
 }
 
-void init_zend_hooks(TSRMLS_D)
+void init_zend_hooks(void)
 {
     if (SEASLOG_G(trace_performance))
     {
@@ -132,7 +132,7 @@ void init_zend_hooks(TSRMLS_D)
     }
 }
 
-void recovery_zend_hooks(TSRMLS_D)
+void recovery_zend_hooks(void)
 {
     if (SEASLOG_G(trace_performance))
     {
@@ -146,7 +146,7 @@ void recovery_zend_hooks(TSRMLS_D)
     }
 }
 
-void seaslog_rinit_performance(TSRMLS_D)
+void seaslog_rinit_performance(void)
 {
     if (SEASLOG_G(trace_performance))
     {
@@ -155,40 +155,40 @@ void seaslog_rinit_performance(TSRMLS_D)
         SEASLOG_G(frame_free_list) = NULL;
         SEASLOG_G(performance_frames) = NULL;
 
-        seaslog_process_performance_sample(TSRMLS_C);
-        if (FAILURE == seaslog_check_performance_sample(TSRMLS_C))
+        seaslog_process_performance_sample();
+        if (FAILURE == seaslog_check_performance_sample())
         {
             return;
         }
 
         SEASLOG_G(performance_main) = (seaslog_performance_main *)emalloc(sizeof(seaslog_performance_main));
-        SEASLOG_G(performance_main)->wt_start = performance_microsecond(TSRMLS_C);
-        SEASLOG_G(performance_main)->mu_start = zend_memory_usage(0 TSRMLS_CC);
+        SEASLOG_G(performance_main)->wt_start = performance_microsecond();
+        SEASLOG_G(performance_main)->mu_start = zend_memory_usage(0 );
     }
 }
 
-void seaslog_clear_performance(zend_class_entry *ce TSRMLS_DC)
+void seaslog_clear_performance(zend_class_entry *ce )
 {
     if (SEASLOG_G(trace_performance))
     {
-        if (FAILURE == seaslog_check_performance_sample(TSRMLS_C))
+        if (FAILURE == seaslog_check_performance_sample())
         {
             return;
         }
 
         SEASLOG_G(stack_level) = 0;
-        seaslog_performance_free_the_free_list(TSRMLS_C);
+        seaslog_performance_free_the_free_list();
 
-        SEASLOG_G(performance_main)->wall_time = performance_microsecond(TSRMLS_C) - SEASLOG_G(performance_main)->wt_start;
-        SEASLOG_G(performance_main)->memory = zend_memory_usage(0 TSRMLS_CC) - SEASLOG_G(performance_main)->mu_start;
+        SEASLOG_G(performance_main)->wall_time = performance_microsecond() - SEASLOG_G(performance_main)->wt_start;
+        SEASLOG_G(performance_main)->memory = zend_memory_usage(0 ) - SEASLOG_G(performance_main)->mu_start;
 
         if (SEASLOG_G(performance_main)->wall_time >= SEASLOG_G(trace_performance_min_wall_time) * 1000)
         {
-            process_seaslog_performance_log(ce TSRMLS_CC);
+            process_seaslog_performance_log(ce );
         }
         else
         {
-            process_seaslog_performance_clear(TSRMLS_C);
+            process_seaslog_performance_clear();
         }
 
         efree(SEASLOG_G(performance_main));
@@ -198,7 +198,7 @@ void seaslog_clear_performance(zend_class_entry *ce TSRMLS_DC)
     }
 }
 
-int seaslog_check_performance_active(TSRMLS_D)
+int seaslog_check_performance_active(void)
 {
     if (SEASLOG_G(trace_performance) && SUCCESS == SEASLOG_G(trace_performance_active))
     {
@@ -209,9 +209,9 @@ int seaslog_check_performance_active(TSRMLS_D)
 }
 
 #if PHP_VERSION_ID >= 50500
-ZEND_DLEXPORT void seaslog_execute_ex (zend_execute_data *execute_data TSRMLS_DC)
+ZEND_DLEXPORT void seaslog_execute_ex (zend_execute_data *execute_data )
 #else
-ZEND_DLEXPORT void seaslog_execute (zend_op_array *ops TSRMLS_DC)
+ZEND_DLEXPORT void seaslog_execute (zend_op_array *ops )
 #endif
 {
     int is_tracing = FAILURE;
@@ -221,17 +221,17 @@ ZEND_DLEXPORT void seaslog_execute (zend_op_array *ops TSRMLS_DC)
 #endif
 
     zend_execute_data *real_execute_data = execute_data;
-    is_tracing = performance_frame_begin(real_execute_data TSRMLS_CC);
+    is_tracing = performance_frame_begin(real_execute_data );
 
 #if PHP_VERSION_ID >= 50500
-    _clone_zend_execute_ex(execute_data TSRMLS_CC);
+    _clone_zend_execute_ex(execute_data );
 #else
-    _clone_zend_execute(ops TSRMLS_CC);
+    _clone_zend_execute(ops );
 #endif
 
     if (SUCCESS == is_tracing)
     {
-        performance_frame_end(TSRMLS_C);
+        performance_frame_end();
     }
     else if (SEASLOG_CONTINUE == is_tracing)
     {
@@ -243,50 +243,50 @@ ZEND_DLEXPORT void seaslog_execute (zend_op_array *ops TSRMLS_DC)
 #if PHP_VERSION_ID >= 70000
 ZEND_DLEXPORT void seaslog_execute_internal(zend_execute_data *execute_data, zval *ret)
 #elif PHP_VERSION_ID >= 50500
-ZEND_DLEXPORT void seaslog_execute_internal(zend_execute_data *execute_data, struct _zend_fcall_info *zfi, int ret TSRMLS_DC)
+ZEND_DLEXPORT void seaslog_execute_internal(zend_execute_data *execute_data, struct _zend_fcall_info *zfi, int ret )
 #else
-ZEND_DLEXPORT void seaslog_execute_internal(zend_execute_data *execute_data, int ret TSRMLS_DC)
+ZEND_DLEXPORT void seaslog_execute_internal(zend_execute_data *execute_data, int ret )
 #endif
 {
 
     int is_tracing = FAILURE;
 
     zend_execute_data *real_execute_data = execute_data;
-    is_tracing = performance_frame_begin(real_execute_data TSRMLS_CC);
+    is_tracing = performance_frame_begin(real_execute_data );
 
 
 #if PHP_VERSION_ID >= 70000
     if (_clone_zend_execute_internal)
     {
-        _clone_zend_execute_internal(execute_data, ret TSRMLS_CC);
+        _clone_zend_execute_internal(execute_data, ret );
     }
     else
     {
-        execute_internal(execute_data, ret TSRMLS_CC);
+        execute_internal(execute_data, ret );
     }
 #elif PHP_VERSION_ID >= 50500
     if (_clone_zend_execute_internal)
     {
-        _clone_zend_execute_internal(execute_data, zfi, ret TSRMLS_CC);
+        _clone_zend_execute_internal(execute_data, zfi, ret );
     }
     else
     {
-        execute_internal(execute_data, zfi, ret TSRMLS_CC);
+        execute_internal(execute_data, zfi, ret );
     }
 #else
     if (_clone_zend_execute_internal)
     {
-        _clone_zend_execute_internal(execute_data, ret TSRMLS_CC);
+        _clone_zend_execute_internal(execute_data, ret );
     }
     else
     {
-        execute_internal(execute_data, ret TSRMLS_CC);
+        execute_internal(execute_data, ret );
     }
 #endif
 
     if (SUCCESS == is_tracing)
     {
-        performance_frame_end(TSRMLS_C);
+        performance_frame_end();
     }
     else if (SEASLOG_CONTINUE == is_tracing)
     {
@@ -294,7 +294,7 @@ ZEND_DLEXPORT void seaslog_execute_internal(zend_execute_data *execute_data, int
     }
 }
 
-int performance_frame_begin(zend_execute_data *execute_data TSRMLS_DC)
+int performance_frame_begin(zend_execute_data *execute_data )
 {
     char *function;
     seaslog_frame *current_frame;
@@ -302,17 +302,17 @@ int performance_frame_begin(zend_execute_data *execute_data TSRMLS_DC)
     int recurse_level = 0;
     int stack_level = 0;
 
-    if (FAILURE == seaslog_check_performance_sample(TSRMLS_C))
+    if (FAILURE == seaslog_check_performance_sample())
     {
         return FAILURE;
     }
 
-    if (FAILURE == seaslog_check_performance_active(TSRMLS_C))
+    if (FAILURE == seaslog_check_performance_active())
     {
         return FAILURE;
     }
 
-    function = seaslog_performance_get_function_name(execute_data TSRMLS_CC);
+    function = seaslog_performance_get_function_name(execute_data );
     if (NULL == function)
     {
         return FAILURE;
@@ -326,12 +326,12 @@ int performance_frame_begin(zend_execute_data *execute_data TSRMLS_DC)
         return SEASLOG_CONTINUE;
     }
 
-    current_frame = seaslog_performance_fast_alloc_frame(TSRMLS_C);
-    current_frame->class_name = seaslog_performance_get_class_name(execute_data TSRMLS_CC);
+    current_frame = seaslog_performance_fast_alloc_frame();
+    current_frame->class_name = seaslog_performance_get_class_name(execute_data );
     current_frame->function_name = function;
     current_frame->previous_frame = SEASLOG_G(performance_frames);
-    current_frame->wt_start = performance_microsecond(TSRMLS_C);
-    current_frame->mu_start = zend_memory_usage(0 TSRMLS_CC);
+    current_frame->wt_start = performance_microsecond();
+    current_frame->mu_start = zend_memory_usage(0 );
     current_frame->hash_code = zend_inline_hash_func(function,strlen(function)+1) % SEASLOG_PERFORMANCE_COUNTER_SIZE;
 
     stack_level = SEASLOG_G(stack_level) - SEASLOG_G(trace_performance_start_depth) + 1;
@@ -370,12 +370,12 @@ int performance_frame_begin(zend_execute_data *execute_data TSRMLS_DC)
     return SUCCESS;
 }
 
-static inline void seaslog_performance_bucket_process(seaslog_frame* current_frame TSRMLS_DC)
+static inline void seaslog_performance_bucket_process(seaslog_frame* current_frame )
 {
     zend_ulong bucket_key = current_frame->hash_code + current_frame->stack_level;
     unsigned int slot = (unsigned int)bucket_key % SEASLOG_PERFORMANCE_BUCKET_SLOTS;
     seaslog_performance_bucket *bucket = SEASLOG_G(performance_buckets)[slot];
-    long duration = performance_microsecond(TSRMLS_C) - current_frame->wt_start;
+    long duration = performance_microsecond() - current_frame->wt_start;
 
     while (bucket)
     {
@@ -418,24 +418,24 @@ static inline void seaslog_performance_bucket_process(seaslog_frame* current_fra
 
     bucket->count++;
     bucket->wall_time += duration;
-    bucket->memory += (zend_memory_usage(0 TSRMLS_CC) - current_frame->mu_start);
+    bucket->memory += (zend_memory_usage(0 ) - current_frame->mu_start);
 }
 
-void performance_frame_end(TSRMLS_D)
+void performance_frame_end(void)
 {
     seaslog_frame *current_frame = SEASLOG_G(performance_frames);
     seaslog_frame *previous_frame = current_frame->previous_frame;
 
-    seaslog_performance_bucket_process(current_frame TSRMLS_CC);
+    seaslog_performance_bucket_process(current_frame );
 
     SEASLOG_G(stack_level) -= 1;
     SEASLOG_G(function_hash_counters)[current_frame->hash_code]--;
 
     SEASLOG_G(performance_frames) = SEASLOG_G(performance_frames)->previous_frame;
-    seaslog_performance_fast_free_frame(current_frame TSRMLS_CC);
+    seaslog_performance_fast_free_frame(current_frame );
 }
 
-void seaslog_performance_bucket_free(seaslog_performance_bucket *bucket TSRMLS_DC)
+void seaslog_performance_bucket_free(seaslog_performance_bucket *bucket )
 {
     if (bucket->class_name)
     {
@@ -450,7 +450,7 @@ void seaslog_performance_bucket_free(seaslog_performance_bucket *bucket TSRMLS_D
     efree(bucket);
 }
 
-seaslog_frame* seaslog_performance_fast_alloc_frame(TSRMLS_D)
+seaslog_frame* seaslog_performance_fast_alloc_frame(void)
 {
     seaslog_frame *p;
 
@@ -472,7 +472,7 @@ seaslog_frame* seaslog_performance_fast_alloc_frame(TSRMLS_D)
     }
 }
 
-void seaslog_performance_fast_free_frame(seaslog_frame *p TSRMLS_DC)
+void seaslog_performance_fast_free_frame(seaslog_frame *p )
 {
     if (p->function_name != NULL)
     {
@@ -487,7 +487,7 @@ void seaslog_performance_fast_free_frame(seaslog_frame *p TSRMLS_DC)
     SEASLOG_G(frame_free_list) = p;
 }
 
-void seaslog_performance_free_the_free_list(TSRMLS_D)
+void seaslog_performance_free_the_free_list(void)
 {
     seaslog_frame *frame = SEASLOG_G(frame_free_list);
     seaslog_frame *current;
@@ -500,7 +500,7 @@ void seaslog_performance_free_the_free_list(TSRMLS_D)
     }
 }
 
-char* seaslog_performance_get_class_name(zend_execute_data *data TSRMLS_DC)
+char* seaslog_performance_get_class_name(zend_execute_data *data )
 {
     zend_function *curr_func;
 
@@ -523,7 +523,7 @@ char* seaslog_performance_get_class_name(zend_execute_data *data TSRMLS_DC)
     return NULL;
 }
 
-char* seaslog_performance_get_function_name(zend_execute_data *data TSRMLS_DC)
+char* seaslog_performance_get_function_name(zend_execute_data *data )
 {
     zend_function *curr_func;
 
@@ -546,7 +546,7 @@ char* seaslog_performance_get_function_name(zend_execute_data *data TSRMLS_DC)
     return STR_NAME_VAL(curr_func->common.function_name);
 }
 
-int process_seaslog_performance_log(zend_class_entry *ce TSRMLS_DC)
+int process_seaslog_performance_log(zend_class_entry *ce )
 {
     int i,j,m,n,r,stack_level = 0;
     seaslog_performance_bucket *bucket;
@@ -650,7 +650,7 @@ int process_seaslog_performance_log(zend_class_entry *ce TSRMLS_DC)
             }
         }
     }
-    seaslog_performance_bucket_free(bucket TSRMLS_CC);
+    seaslog_performance_bucket_free(bucket );
     bucket = SEASLOG_G(performance_buckets)[i];
     SEASLOG_PERFORMANCE_BUCKET_FOREACH_END;
 
@@ -692,12 +692,12 @@ int process_seaslog_performance_log(zend_class_entry *ce TSRMLS_DC)
     }
     efree(result_array);
 
-//    php_var_dump(&performance_log_array,1 TSRMLS_CC);
+//    php_var_dump(&performance_log_array,1 );
 
     SEASLOG_JSON_ENCODE(&performance_log, performance_log_array, 0);
     smart_str_0(&performance_log);
 
-    seaslog_log_ex(3, SEASLOG_INFO, SEASLOG_INFO_INT, SEASLOG_SMART_STR_C(performance_log), seaslog_smart_str_get_len(performance_log), SEASLOG_PERFORMANCE_LOGGER, strlen(SEASLOG_PERFORMANCE_LOGGER)+1, ce TSRMLS_CC);
+    seaslog_log_ex(3, SEASLOG_INFO, SEASLOG_INFO_INT, SEASLOG_SMART_STR_C(performance_log), seaslog_smart_str_get_len(performance_log), SEASLOG_PERFORMANCE_LOGGER, strlen(SEASLOG_PERFORMANCE_LOGGER)+1, ce );
     smart_str_free(&performance_log);
 
     SEASLOG_ARRAY_DESTROY(performance_log_array);
@@ -705,14 +705,14 @@ int process_seaslog_performance_log(zend_class_entry *ce TSRMLS_DC)
     return SUCCESS;
 }
 
-int process_seaslog_performance_clear(TSRMLS_D)
+int process_seaslog_performance_clear(void)
 {
     int i;
     seaslog_performance_bucket *bucket;
 
     SEASLOG_PERFORMANCE_BUCKET_FOREACH(bucket, i)
     SEASLOG_G(performance_buckets)[i] = bucket->next;
-    seaslog_performance_bucket_free(bucket TSRMLS_CC);
+    seaslog_performance_bucket_free(bucket );
     bucket = SEASLOG_G(performance_buckets)[i];
     SEASLOG_PERFORMANCE_BUCKET_FOREACH_END;
 

--- a/src/Request.c
+++ b/src/Request.c
@@ -17,7 +17,7 @@
 #include "Request.h"
 #include "Common.h"
 
-void seaslog_init_host_name(TSRMLS_D)
+void seaslog_init_host_name(void)
 {
     char buf[255];
 
@@ -32,7 +32,7 @@ void seaslog_init_host_name(TSRMLS_D)
     }
 }
 
-void seaslog_clear_host_name(TSRMLS_D)
+void seaslog_clear_host_name(void)
 {
     if (SEASLOG_G(host_name))
     {
@@ -40,12 +40,12 @@ void seaslog_clear_host_name(TSRMLS_D)
     }
 }
 
-void seaslog_init_pid(TSRMLS_D)
+void seaslog_init_pid(void)
 {
     SEASLOG_G(process_id_len) = spprintf(&SEASLOG_G(process_id),0, "%d", getpid());
 }
 
-void seaslog_clear_pid(TSRMLS_D)
+void seaslog_clear_pid(void)
 {
     if (SEASLOG_G(process_id))
     {
@@ -53,13 +53,13 @@ void seaslog_clear_pid(TSRMLS_D)
     }
 }
 
-void seaslog_init_request_id(TSRMLS_D)
+void seaslog_init_request_id(void)
 {
     SEASLOG_G(request_id) = get_uniqid();
     SEASLOG_G(request_id_len) = strlen(SEASLOG_G(request_id));
 }
 
-void seaslog_clear_request_id(TSRMLS_D)
+void seaslog_clear_request_id(void)
 {
     if (SEASLOG_G(request_id))
     {
@@ -67,13 +67,13 @@ void seaslog_clear_request_id(TSRMLS_D)
     }
 }
 
-void seaslog_init_auto_globals(TSRMLS_D)
+void seaslog_init_auto_globals(void)
 {
     SEASLOG_AUTO_GLOBAL("_SERVER");
 }
 
 
-zval *seaslog_request_query(SEASLOG_UINT query_type, void *name, size_t len TSRMLS_DC)
+zval *seaslog_request_query(SEASLOG_UINT query_type, void *name, size_t len )
 {
 #if PHP_VERSION_ID >= 70000
     zval *carrier = NULL, *ret;
@@ -129,7 +129,7 @@ zval *seaslog_request_query(SEASLOG_UINT query_type, void *name, size_t len TSRM
 #endif
 }
 
-int seaslog_init_request_variable(TSRMLS_D)
+int seaslog_init_request_variable(void)
 {
     zval *client_ip;
     zval *domain;
@@ -140,14 +140,14 @@ int seaslog_init_request_variable(TSRMLS_D)
 
     if (!strncmp(sapi_module.name, SEASLOG_CLI_KEY, sizeof(SEASLOG_CLI_KEY) - 1) || !strncmp(sapi_module.name, SEASLOG_PHPDBG_KEY, sizeof(SEASLOG_PHPDBG_KEY) - 1))
     {
-        request_uri = seaslog_request_query(SEASLOG_GLOBAL_VARS_SERVER, ZEND_STRL("SCRIPT_NAME") TSRMLS_CC);
+        request_uri = seaslog_request_query(SEASLOG_GLOBAL_VARS_SERVER, ZEND_STRL("SCRIPT_NAME") );
         if (request_uri != NULL && IS_STRING == Z_TYPE_P(request_uri))
         {
             SEASLOG_G(request_variable)->request_uri_len = spprintf(&SEASLOG_G(request_variable)->request_uri, 0, "%s", Z_STRVAL_P(request_uri));
             SEASLOG_ZVAL_PTR_DTOR(request_uri);
         }
 
-        request_method = seaslog_request_query(SEASLOG_GLOBAL_VARS_SERVER, ZEND_STRL("SHELL") TSRMLS_CC);
+        request_method = seaslog_request_query(SEASLOG_GLOBAL_VARS_SERVER, ZEND_STRL("SHELL") );
         if (request_method != NULL && IS_STRING == Z_TYPE_P(request_method))
         {
             SEASLOG_G(request_variable)->request_method_len = spprintf(&SEASLOG_G(request_variable)->request_method, 0, "%s", Z_STRVAL_P(request_method));
@@ -159,28 +159,28 @@ int seaslog_init_request_variable(TSRMLS_D)
     }
     else
     {
-        domain = seaslog_request_query(SEASLOG_GLOBAL_VARS_SERVER, ZEND_STRL("HTTP_HOST") TSRMLS_CC);
+        domain = seaslog_request_query(SEASLOG_GLOBAL_VARS_SERVER, ZEND_STRL("HTTP_HOST") );
         if (domain != NULL && IS_STRING == Z_TYPE_P(domain))
         {
             SEASLOG_G(request_variable)->domain_port_len = spprintf(&SEASLOG_G(request_variable)->domain_port, 0, "%s", Z_STRVAL_P(domain));
             SEASLOG_ZVAL_PTR_DTOR(domain);
         }
 
-        request_uri = seaslog_request_query(SEASLOG_GLOBAL_VARS_SERVER, ZEND_STRL("REQUEST_URI") TSRMLS_CC);
+        request_uri = seaslog_request_query(SEASLOG_GLOBAL_VARS_SERVER, ZEND_STRL("REQUEST_URI") );
         if (request_uri != NULL && IS_STRING == Z_TYPE_P(request_uri))
         {
             SEASLOG_G(request_variable)->request_uri_len = spprintf(&SEASLOG_G(request_variable)->request_uri, 0, "%s", Z_STRVAL_P(request_uri));
             SEASLOG_ZVAL_PTR_DTOR(request_uri);
         }
 
-        request_method = seaslog_request_query(SEASLOG_GLOBAL_VARS_SERVER, ZEND_STRL("REQUEST_METHOD") TSRMLS_CC);
+        request_method = seaslog_request_query(SEASLOG_GLOBAL_VARS_SERVER, ZEND_STRL("REQUEST_METHOD") );
         if (request_method != NULL && IS_STRING == Z_TYPE_P(request_method))
         {
             SEASLOG_G(request_variable)->request_method_len = spprintf(&SEASLOG_G(request_variable)->request_method, 0, "%s", Z_STRVAL_P(request_method));
             SEASLOG_ZVAL_PTR_DTOR(request_method);
         }
 
-        client_ip = seaslog_request_query(SEASLOG_GLOBAL_VARS_SERVER, ZEND_STRL("HTTP_X_REAL_IP") TSRMLS_CC);
+        client_ip = seaslog_request_query(SEASLOG_GLOBAL_VARS_SERVER, ZEND_STRL("HTTP_X_REAL_IP") );
         if (client_ip != NULL && IS_STRING == Z_TYPE_P(client_ip))
         {
             SEASLOG_G(request_variable)->client_ip_len = spprintf(&SEASLOG_G(request_variable)->client_ip, 0, "%s", Z_STRVAL_P(client_ip));
@@ -188,7 +188,7 @@ int seaslog_init_request_variable(TSRMLS_D)
             return SUCCESS;
         }
 
-        client_ip = seaslog_request_query(SEASLOG_GLOBAL_VARS_SERVER, ZEND_STRL("HTTP_X_FORWARDED_FOR") TSRMLS_CC);
+        client_ip = seaslog_request_query(SEASLOG_GLOBAL_VARS_SERVER, ZEND_STRL("HTTP_X_FORWARDED_FOR") );
         if (client_ip != NULL && IS_STRING == Z_TYPE_P(client_ip))
         {
             SEASLOG_G(request_variable)->client_ip_len = spprintf(&SEASLOG_G(request_variable)->client_ip, 0, "%s", Z_STRVAL_P(client_ip));
@@ -196,7 +196,7 @@ int seaslog_init_request_variable(TSRMLS_D)
             return SUCCESS;
         }
 
-        client_ip = seaslog_request_query(SEASLOG_GLOBAL_VARS_SERVER, ZEND_STRL("REMOTE_ADDR") TSRMLS_CC);
+        client_ip = seaslog_request_query(SEASLOG_GLOBAL_VARS_SERVER, ZEND_STRL("REMOTE_ADDR") );
         if (client_ip != NULL && IS_STRING == Z_TYPE_P(client_ip))
         {
             SEASLOG_G(request_variable)->client_ip_len = spprintf(&SEASLOG_G(request_variable)->client_ip, 0, "%s", Z_STRVAL_P(client_ip));
@@ -208,7 +208,7 @@ int seaslog_init_request_variable(TSRMLS_D)
     return SUCCESS;
 }
 
-void seaslog_clear_request_variable(TSRMLS_D)
+void seaslog_clear_request_variable(void)
 {
     if(SEASLOG_G(request_variable)->request_uri)
     {
@@ -233,7 +233,7 @@ void seaslog_clear_request_variable(TSRMLS_D)
     efree(SEASLOG_G(request_variable));
 }
 
-void get_code_filename_line(smart_str *result TSRMLS_DC)
+void get_code_filename_line(smart_str *result )
 {
     const char *ret;
     size_t retlen = 0;
@@ -333,9 +333,9 @@ void get_code_filename_line(smart_str *result TSRMLS_DC)
     }
 
 #if PHP_VERSION_ID >= 50400
-    php_basename(ret, retlen, NULL, 0, &filename, &filename_len TSRMLS_CC);
+    php_basename(ret, retlen, NULL, 0, &filename, &filename_len );
 #else
-    php_basename((char *)ret, retlen, NULL, 0, &filename, &filename_len TSRMLS_CC);
+    php_basename((char *)ret, retlen, NULL, 0, &filename, &filename_len );
 #endif
 
     smart_str_appendl(result,filename,filename_len);

--- a/src/StreamWrapper.c
+++ b/src/StreamWrapper.c
@@ -18,7 +18,7 @@
 #include "ErrorHook.h"
 #include "ExceptionHook.h"
 
-php_stream *seaslog_stream_open_wrapper(char *opt TSRMLS_DC)
+php_stream *seaslog_stream_open_wrapper(char *opt )
 {
     php_stream *stream = NULL;
     char *res = NULL;
@@ -38,7 +38,7 @@ php_stream *seaslog_stream_open_wrapper(char *opt TSRMLS_DC)
 
         if (stream == NULL)
         {
-            seaslog_throw_exception(SEASLOG_EXCEPTION_LOGGER_ERROR TSRMLS_CC, "SeasLog Can Not Create TCP Connect - %s", res);
+            seaslog_throw_exception(SEASLOG_EXCEPTION_LOGGER_ERROR , "SeasLog Can Not Create TCP Connect - %s", res);
             efree(res);
             return NULL;
         }
@@ -52,7 +52,7 @@ php_stream *seaslog_stream_open_wrapper(char *opt TSRMLS_DC)
 
         if (stream == NULL)
         {
-            seaslog_throw_exception(SEASLOG_EXCEPTION_LOGGER_ERROR TSRMLS_CC, "SeasLog Can Not Create UDP Connect - %s", res);
+            seaslog_throw_exception(SEASLOG_EXCEPTION_LOGGER_ERROR , "SeasLog Can Not Create UDP Connect - %s", res);
             efree(res);
             return NULL;
         }
@@ -70,7 +70,7 @@ php_stream *seaslog_stream_open_wrapper(char *opt TSRMLS_DC)
 
         if (stream == NULL)
         {
-            seaslog_throw_exception(SEASLOG_EXCEPTION_LOGGER_ERROR TSRMLS_CC, "SeasLog Invalid Log File - %s", opt);
+            seaslog_throw_exception(SEASLOG_EXCEPTION_LOGGER_ERROR , "SeasLog Invalid Log File - %s", opt);
             return NULL;
         }
         else
@@ -85,7 +85,7 @@ php_stream *seaslog_stream_open_wrapper(char *opt TSRMLS_DC)
     return stream;
 }
 
-void seaslog_init_stream_list(TSRMLS_D)
+void seaslog_init_stream_list(void)
 {
     zval *z_stream_list;
 
@@ -101,7 +101,7 @@ void seaslog_init_stream_list(TSRMLS_D)
 
 }
 
-int seaslog_clear_stream(int destroy, int model, char *opt TSRMLS_DC)
+int seaslog_clear_stream(int destroy, int model, char *opt )
 {
     php_stream *stream = NULL;
     HashTable *ht;
@@ -185,7 +185,7 @@ int seaslog_clear_stream(int destroy, int model, char *opt TSRMLS_DC)
     return result;
 }
 
-php_stream *process_stream(char *opt, int opt_len TSRMLS_DC)
+php_stream *process_stream(char *opt, int opt_len )
 {
     ulong stream_entry_hash;
     php_stream *stream = NULL;
@@ -269,7 +269,7 @@ php_stream *process_stream(char *opt, int opt_len TSRMLS_DC)
     else
     {
 create_stream:
-        stream = seaslog_stream_open_wrapper(opt TSRMLS_CC);
+        stream = seaslog_stream_open_wrapper(opt );
         if (stream == NULL)
         {
             return NULL;

--- a/src/TemplateFormatter.c
+++ b/src/TemplateFormatter.c
@@ -40,7 +40,7 @@
 	smart_str_appendl(xbuf, s, slen);	\
 } while (0)
 
-static smart_str* get_class_and_action(smart_str *result  TSRMLS_DC)
+static smart_str* get_class_and_action(smart_str *result  )
 {
     char *func;
     char *cls;
@@ -83,13 +83,13 @@ static smart_str* get_class_and_action(smart_str *result  TSRMLS_DC)
     }
 #endif
 
-    func = seaslog_performance_get_function_name(execute_data TSRMLS_CC);
+    func = seaslog_performance_get_function_name(execute_data );
     if (!func)
     {
         return NULL;
     }
 
-    cls = seaslog_performance_get_class_name(execute_data TSRMLS_CC);
+    cls = seaslog_performance_get_class_name(execute_data );
     if (cls)
     {
         INS_STRING(result, cls, strlen(cls));
@@ -104,18 +104,18 @@ static smart_str* get_class_and_action(smart_str *result  TSRMLS_DC)
     return result;
 }
 
-void seaslog_init_template(TSRMLS_D)
+void seaslog_init_template(void)
 {
-    seaslog_spprintf(&SEASLOG_G(current_template) TSRMLS_CC, SEASLOG_GENERATE_CURRENT_TEMPLATE, NULL, 0);
+    seaslog_spprintf(&SEASLOG_G(current_template) , SEASLOG_GENERATE_CURRENT_TEMPLATE, NULL, 0);
 }
 
-void seaslog_re_init_template(TSRMLS_D)
+void seaslog_re_init_template(void)
 {
     efree(SEASLOG_G(current_template));
-    seaslog_spprintf(&SEASLOG_G(current_template) TSRMLS_CC, SEASLOG_GENERATE_RE_CURRENT_TEMPLATE, NULL, 0);
+    seaslog_spprintf(&SEASLOG_G(current_template) , SEASLOG_GENERATE_RE_CURRENT_TEMPLATE, NULL, 0);
 }
 
-void seaslog_clear_template(TSRMLS_D)
+void seaslog_clear_template(void)
 {
     if (SEASLOG_G(current_template))
     {
@@ -127,7 +127,7 @@ void seaslog_clear_template(TSRMLS_D)
     }
 }
 
-int seaslog_spprintf(char **pbuf TSRMLS_DC, int generate_type, char *level, size_t max_len, ...)
+int seaslog_spprintf(char **pbuf , int generate_type, char *level, size_t max_len, ...)
 {
     int len;
     va_list ap;
@@ -140,7 +140,7 @@ int seaslog_spprintf(char **pbuf TSRMLS_DC, int generate_type, char *level, size
     {
     case SEASLOG_GENERATE_CURRENT_TEMPLATE:
     case SEASLOG_GENERATE_RE_CURRENT_TEMPLATE:
-        seaslog_template_formatter(&xbuf TSRMLS_CC, generate_type, SEASLOG_G(default_template), level, ap);
+        seaslog_template_formatter(&xbuf , generate_type, SEASLOG_G(default_template), level, ap);
         break;
     case SEASLOG_GENERATE_LEVEL_TEMPLATE:
         if (strlen(SEASLOG_G(level_template)) == 0 || (level && !strcmp(level, SEASLOG_ALL)))
@@ -149,12 +149,12 @@ int seaslog_spprintf(char **pbuf TSRMLS_DC, int generate_type, char *level, size
         }
         else
         {
-            seaslog_template_formatter(&xbuf TSRMLS_CC, generate_type, SEASLOG_G(level_template), level, ap);
+            seaslog_template_formatter(&xbuf , generate_type, SEASLOG_G(level_template), level, ap);
         }
         break;
     case SEASLOG_GENERATE_SYSLOG_INFO:
     case SEASLOG_GENERATE_LOG_INFO:
-        seaslog_template_formatter(&xbuf TSRMLS_CC, generate_type, SEASLOG_G(current_template), level, ap);
+        seaslog_template_formatter(&xbuf , generate_type, SEASLOG_G(current_template), level, ap);
         break;
     default:
         break;
@@ -175,7 +175,7 @@ int seaslog_spprintf(char **pbuf TSRMLS_DC, int generate_type, char *level, size
     return len;
 }
 
-void seaslog_template_formatter(smart_str *xbuf TSRMLS_DC, int generate_type, const char *fmt, char *level, va_list ap)
+void seaslog_template_formatter(smart_str *xbuf , int generate_type, const char *fmt, char *level, va_list ap)
 {
     char *s = NULL;
     int s_len;
@@ -288,7 +288,7 @@ void seaslog_template_formatter(smart_str *xbuf TSRMLS_DC, int generate_type, co
                 switch (*fmt)
                 {
                 case 'T': //Time  2017:08:16 19:15:02
-                    s = make_real_time(TSRMLS_C);
+                    s = make_real_time();
                     s_len  = strlen(s);
                     break;
                 case 't': //time  1502882102.862
@@ -327,7 +327,7 @@ void seaslog_template_formatter(smart_str *xbuf TSRMLS_DC, int generate_type, co
                     {
                         smart_str_free(&tmp_buf);
                     }
-                    get_code_filename_line(&tmp_buf TSRMLS_CC);
+                    get_code_filename_line(&tmp_buf );
 
                     s = SEASLOG_SMART_STR_C(tmp_buf);
                     s_len = seaslog_smart_str_get_len(tmp_buf);
@@ -337,7 +337,7 @@ void seaslog_template_formatter(smart_str *xbuf TSRMLS_DC, int generate_type, co
                     {
                         smart_str_free(&tmp_buf);
                     }
-                    seaslog_memory_usage(&tmp_buf TSRMLS_CC);
+                    seaslog_memory_usage(&tmp_buf );
                     s = SEASLOG_SMART_STR_C(tmp_buf);
                     s_len = seaslog_smart_str_get_len(tmp_buf);
                     break;
@@ -346,7 +346,7 @@ void seaslog_template_formatter(smart_str *xbuf TSRMLS_DC, int generate_type, co
                     {
                         smart_str_free(&tmp_buf);
                     }
-                    seaslog_peak_memory_usage(&tmp_buf TSRMLS_CC);
+                    seaslog_peak_memory_usage(&tmp_buf );
                     s = SEASLOG_SMART_STR_C(tmp_buf);
                     s_len  = seaslog_smart_str_get_len(tmp_buf);
                     break;
@@ -356,7 +356,7 @@ void seaslog_template_formatter(smart_str *xbuf TSRMLS_DC, int generate_type, co
                         smart_str_free(&tmp_buf);
                     }
 
-                    if (get_class_and_action(&tmp_buf TSRMLS_CC))
+                    if (get_class_and_action(&tmp_buf ))
                     {
                         s = SEASLOG_SMART_STR_C(tmp_buf);
                         s_len  = seaslog_smart_str_get_len(tmp_buf);


### PR DESCRIPTION
https://github.com/php/php-src/blob/e1559b51cdde65400434653c55790279a15475d5/UPGRADING.INTERNALS#L36

```
  c. The following things have been removed from TSRM:
      - TSRMLS_DC
      - TSRMLS_D
      - TSRMLS_CC
      - TSRMLS_C
      - TSRMLS_FETCH
      - TSRMLS_FETCH_FROM_CTX
      - TSRMLS_SET_CTX
      - tsrm_new_interpreter_context
      - tsrm_set_interpreter_context
      - tsrm_free_interpreter_context
      - support for GNUPTH, SGI ST, and BETHREADS
```