### PR TITLE
fix memory leak and test case dependence

### DIFF
--- a/src/Request.c
+++ b/src/Request.c
@@ -280,6 +280,11 @@ void get_code_filename_line(smart_str *result TSRMLS_DC)
         }
     }
 
+    if (retlen == 0)
+    {
+        return;
+    }
+
     filename = php_basename(ret, retlen, NULL, 0);
 
     smart_str_appendl(result,ZSTR_VAL(filename),ZSTR_LEN(filename));
@@ -330,6 +335,11 @@ void get_code_filename_line(smart_str *result TSRMLS_DC)
             retlen = strlen(ret);
             code_line = ptr->prev_execute_data->opline->lineno;
         }
+    }
+
+    if (retlen == 0)
+    {
+        return;
     }
 
 #if PHP_VERSION_ID >= 50400

--- a/tests/016.phpt
+++ b/tests/016.phpt
@@ -8,6 +8,8 @@ if (!extension_loaded('seaslog')
     print 'skip';
 }
 ?>
+--INI--
+seaslog.default_template = "%T | %L | %P | %Q | %t | %M"
 --FILE--
 <?php
 SeasLog::setBasePath('base_path');

--- a/tests/017.phpt
+++ b/tests/017.phpt
@@ -9,6 +9,8 @@ if (!extension_loaded('seaslog')
     print 'skip';
 }
 ?>
+--INI--
+seaslog.default_template = "%T | %L | %P | %Q | %t | %M"
 --FILE--
 <?php
 SeasLog::setBasePath('base_path');

--- a/travis/run-tests.sh
+++ b/travis/run-tests.sh
@@ -1,24 +1,15 @@
 #!/bin/bash
 TEST_DIR="`pwd`/tests/"
 
-TEST_PHP_ARGS="-m --show-diff" make test
+TEST_PHP_ARGS="-m --show-diff -q" make test
 
-for file in `find $TEST_DIR -name "*.diff" 2>/dev/null`
+EXIT_STATUS=0
+
+for file in `find $TEST_DIR -type f ! -name '*.phpt' -and ! -name '*.php' -and ! -name '*.png'`
 do
-	grep "\-\-XFAIL--" ${file/%diff/phpt} >/dev/null 2>&1
-	if [ $? -gt 0 ]
-	then
-		FAILS[${#FAILS[@]}]="$file"
-	fi
+    echo '====================================================================='
+    sh -xc "cat $file"
+    EXIT_STATUS=1
 done
 
-if [ ${#FAILS[@]} -gt 0 ]
-then
-	for fail in "${FAILS[@]}"
-	do
-		sh -xc "cat $fail"
-	done
-	exit 1
-else
-	exit 0
-fi
+exit $EXIT_STATUS

--- a/travis/run-tests.sh
+++ b/travis/run-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 TEST_DIR="`pwd`/tests/"
 
-make test
+TEST_PHP_ARGS="-m --show-diff" make test
 
 for file in `find $TEST_DIR -name "*.diff" 2>/dev/null`
 do


### PR DESCRIPTION
- fix memory leak on `get_code_filename_line`
- fix: test case dependence on INI setting (seaslog.default_template)