### PR TITLE
php8.0 support

### DIFF
--- a/include/ExceptionHook.h
+++ b/include/ExceptionHook.h
@@ -22,7 +22,11 @@
 void seaslog_throw_exception(int type TSRMLS_DC, const char *format, ...);
 void init_exception_hooks(TSRMLS_D);
 void recovery_exception_hooks(TSRMLS_D);
+#if PHP_VERSION_ID < 80000
 void seaslog_throw_exception_hook(zval *exception TSRMLS_DC);
+#else
+void seaslog_throw_exception_hook(zend_object *exception);
+#endif
 
 #endif /* _SEASLOG_EXCEPTIONHOOK_H_ */
 

--- a/include/SeasLog.h
+++ b/include/SeasLog.h
@@ -45,6 +45,10 @@
 #define ZEND_ACC_DTOR 0
 #endif
 
+#ifndef IGNORE_URL_WIN
+#define IGNORE_URL_WIN 0
+#endif
+
 #include <stdlib.h>
 
 #define SEASLOG_RES_NAME                        "SeasLog"


### PR DESCRIPTION
Hello!
   1. Fix seaslog_error_cb  ( zend_error_cb has been updated .) https://github.com/php/php-src/pull/5639
   2. Fix  seaslog_throw_exception_hook zval* to zend_object* ( php8.0 crashed when seaslog.trace_exception=1 )
   3. IGNORE_URL_WIN has been removed from php-src master  https://github.com/php/php-src/pull/6351
   
#300 
```
=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :   32
---------------------------------------------------------------------

Number of tests :   22                22
Tests skipped   :    0 (  0.0%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Tests passed    :   22 (100.0%) (100.0%)
---------------------------------------------------------------------
Time taken      :    3 seconds
=====================================================================
```
