### PR TITLE
Fix seaslog_error_cb error type

### DIFF
--- a/src/ErrorHook.c
+++ b/src/ErrorHook.c
@@ -43,7 +43,7 @@ static void process_event_error(const char *event_type, int type, char * error_f
 #if PHP_VERSION_ID < 80000
 void seaslog_error_cb(int type, const char *error_filename, const SEASLOG_UINT error_lineno, const char *format, va_list args)
 #else
-void seaslog_error_cb(int type, const char *error_filename, const SEASLOG_UINT error_lineno,zend_string *message)
+void seaslog_error_cb(int orig_type, const char *error_filename, const SEASLOG_UINT error_lineno,zend_string *message)
 #endif
 {
     TSRMLS_FETCH();
@@ -52,7 +52,7 @@ void seaslog_error_cb(int type, const char *error_filename, const SEASLOG_UINT e
 #if PHP_VERSION_ID < 80000
         return old_error_cb(type, error_filename, error_lineno, format, args);
 #else
-        return old_error_cb(type, error_filename, error_lineno, message);
+        return old_error_cb(orig_type, error_filename, error_lineno, message);
 #endif
     }
 
@@ -71,6 +71,7 @@ void seaslog_error_cb(int type, const char *error_filename, const SEASLOG_UINT e
         va_end(args_copy);
 #else
         char *msg = ZSTR_VAL(message);
+        int type = orig_type & E_ALL;
 #endif
         if (type == E_ERROR || type == E_PARSE || type == E_CORE_ERROR || type == E_COMPILE_ERROR || type == E_USER_ERROR || type == E_RECOVERABLE_ERROR)
         {
@@ -100,7 +101,7 @@ void seaslog_error_cb(int type, const char *error_filename, const SEASLOG_UINT e
 #if PHP_VERSION_ID < 80000
     return old_error_cb(type, error_filename, error_lineno, format, args);
 #else
-    return old_error_cb(type, error_filename, error_lineno, message);
+    return old_error_cb(orig_type, error_filename, error_lineno, message);
 #endif
 }
 


### PR DESCRIPTION
Dear all seasloger
php8的php_error_cb的type返回值改成了orig_type的值[int type = orig_type & E_ALL;]，与E_ALL做下位与运算取到原逻辑的type~